### PR TITLE
CreateConnectToken fails with ItemId as `null`

### DIFF
--- a/Pluggy.SDK/PluggyAPI.cs
+++ b/Pluggy.SDK/PluggyAPI.cs
@@ -374,11 +374,9 @@ namespace Pluggy.SDK
         {
             try
             {
-                var body = new Dictionary<string, object>
-                {
-                    { "itemId", itemId?.ToString() },
-                    { "options", options }
-                };
+                var body = new Dictionary<string, object>();
+                if (itemId != null) body.Add("itemId", itemId);
+                if (options != null) body.Add("options", options);
                 return await httpService.PostAsync<ConnectTokenResponse>(URL_CONNECT_TOKEN, body);
             }
             catch (ApiException e)


### PR DESCRIPTION
Hello,

I am working on building an integration with the Pluggy API. Our codebase is in .NET/C#, so I am trying to make use of your C# Pluggy Client package. I am running into an issue when attempting to create a connect token using this library. The API error response I am receiving is `itemId must be a UUID, nested property options.options must be either object or array`. My usage is as followed:

```c#
var pluggyClient = new PluggyAPI(myClientId, myClientSecret, baseUrl);
var connectToken = await pluggyClient.CreateConnectToken();
```

I am able to reproduce this behavior in Postman as well when I send the request body as:

```json
{
  "itemId": null,
  "options": null
}
```

Which is what the client is doing with the `Dictionary<string, object>` since it doesn't check whether the `itemId` or `options` are `null` or not. This change set simply adds the checking before attempting to add anything to the dictionary. In Postman, the below request body is successful, so simply passing an empty dictionary should work as well.

```json
{}
```