### PR TITLE
feat(http): enable gzip/deflate response compression

### DIFF
--- a/Pluggy.SDK/HTTP/APIService.cs
+++ b/Pluggy.SDK/HTTP/APIService.cs
@@ -36,7 +36,10 @@ namespace Pluggy.SDK.HTTP
             _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId), "ClientId is required to execute");
             _clientSecret = clientSecret ?? throw new ArgumentNullException(nameof(clientSecret), "ClientSecret is required to execute");
             _baseUrl = baseUrl;
-            _httpClient = httpClient ?? new HttpClient(new HttpClientHandler());
+            _httpClient = httpClient ?? new HttpClient(new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            });
             _ownHttpClient = httpClient == null;
         }
 


### PR DESCRIPTION
## Summary
- Configure the default `HttpClientHandler` with `AutomaticDecompression = GZip | Deflate` so the SDK advertises `Accept-Encoding` and transparently decompresses Pluggy API responses.
- Previously no `Accept-Encoding` header was sent and no decompression was configured, so responses from endpoints like `/transactions` or `/investments/{id}/transactions` were fetched uncompressed, wasting bandwidth.
- Brotli (`br`) is intentionally excluded: `DecompressionMethods.Brotli` is not available on `netstandard2.0` (the SDK's target framework).
- Consumers that inject their own `HttpClient` remain responsible for configuring decompression on their handler.

## Test plan
- [ ] `dotnet build` succeeds on `netstandard2.0`
- [ ] `dotnet test` passes
- [ ] Manual: capture an outgoing request (e.g., Fiddler/mitmproxy) and confirm `Accept-Encoding: gzip, deflate` is present
- [ ] Manual: confirm response from `/transactions` is received with `Content-Encoding: gzip` and deserializes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)