### PR TITLE
feat(identity): add PF/PJ identity fields exposed by Pluggy API 0.24

### DIFF
--- a/Pluggy.SDK/Model/Address.cs
+++ b/Pluggy.SDK/Model/Address.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Pluggy.SDK.Model
 {
@@ -27,6 +27,22 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("additionalInfo")]
         public string AdditionalInfo { get; set; }
+
+        /// <summary>District / neighborhood (bairro).</summary>
+        [JsonProperty("district")]
+        public string District { get; set; }
+
+        /// <summary>IBGE municipality code (7 digits). The first two digits identify the Federation Unit.</summary>
+        [JsonProperty("ibgeTownCode")]
+        public string IbgeTownCode { get; set; }
+
+        /// <summary>Country code in alpha3 ISO-3166 format (e.g. 'BRA').</summary>
+        [JsonProperty("countryCode")]
+        public string CountryCode { get; set; }
+
+        /// <summary>Geographic coordinates of the address.</summary>
+        [JsonProperty("geographicCoordinates")]
+        public GeographicCoordinates GeographicCoordinates { get; set; }
     }
 
     public enum AddressType

--- a/Pluggy.SDK/Model/BusinessOtherDocument.cs
+++ b/Pluggy.SDK/Model/BusinessOtherDocument.cs
@@ -1,0 +1,25 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Additional document for businesses headquartered abroad and not required to register a CNPJ.
+    /// </summary>
+    public class BusinessOtherDocument
+    {
+        /// <summary>Type of the document (e.g. 'EIN').</summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        /// <summary>Issuing country in alpha3 ISO-3166 format.</summary>
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("expirationDate")]
+        public DateTime? ExpirationDate { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/BusinessParty.cs
+++ b/Pluggy.SDK/Model/BusinessParty.cs
@@ -1,0 +1,81 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Partner or administrator of a business. Partners with less than 25% shareholding
+    /// may be omitted by the institution.
+    /// </summary>
+    public class BusinessParty
+    {
+        [JsonProperty("type")]
+        public BusinessPartyType Type { get; set; }
+
+        [JsonProperty("personType")]
+        public BusinessPartyPersonType PersonType { get; set; }
+
+        [JsonProperty("documentType")]
+        public BusinessPartyDocumentType DocumentType { get; set; }
+
+        [JsonProperty("documentNumber")]
+        public string DocumentNumber { get; set; }
+
+        /// <summary>Issuing country of the document, alpha3 ISO-3166.</summary>
+        [JsonProperty("documentCountry")]
+        public string DocumentCountry { get; set; }
+
+        [JsonProperty("documentExpirationDate")]
+        public DateTime? DocumentExpirationDate { get; set; }
+
+        [JsonProperty("documentIssueDate")]
+        public DateTime? DocumentIssueDate { get; set; }
+
+        [JsonProperty("documentAdditionalInfo")]
+        public string DocumentAdditionalInfo { get; set; }
+
+        /// <summary>Civil name. Required when PersonType is NATURAL_PERSON.</summary>
+        [JsonProperty("civilName")]
+        public string CivilName { get; set; }
+
+        [JsonProperty("socialName")]
+        public string SocialName { get; set; }
+
+        /// <summary>Company name. Required when PersonType is LEGAL_ENTITY.</summary>
+        [JsonProperty("companyName")]
+        public string CompanyName { get; set; }
+
+        [JsonProperty("tradeName")]
+        public string TradeName { get; set; }
+
+        [JsonProperty("startDate")]
+        public DateTime? StartDate { get; set; }
+
+        /// <summary>
+        /// Shareholding fraction between 0 and 1 (e.g. 0.51 represents 51%, 1 represents 100%).
+        /// Required when Type is PARTNER and the shareholding is 25% or higher.
+        /// </summary>
+        [JsonProperty("shareholding")]
+        public double? Shareholding { get; set; }
+    }
+
+    public enum BusinessPartyType
+    {
+        PARTNER,
+        ADMINISTRATOR
+    }
+
+    public enum BusinessPartyPersonType
+    {
+        NATURAL_PERSON,
+        LEGAL_ENTITY
+    }
+
+    public enum BusinessPartyDocumentType
+    {
+        CPF,
+        CNPJ,
+        PASSPORT,
+        OTHER_TRAVEL_DOCUMENT
+    }
+}

--- a/Pluggy.SDK/Model/GeographicCoordinates.cs
+++ b/Pluggy.SDK/Model/GeographicCoordinates.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>Geographic coordinates in decimal degrees, WGS84 reference system.</summary>
+    public class GeographicCoordinates
+    {
+        /// <summary>Between -90 and 90.</summary>
+        [JsonProperty("latitude")]
+        public double? Latitude { get; set; }
+
+        /// <summary>Between -180 and 180.</summary>
+        [JsonProperty("longitude")]
+        public double? Longitude { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/Identity.cs
+++ b/Pluggy.SDK/Model/Identity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -59,5 +59,47 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("establishmentName")]
         public string EstablishmentName { get; set; }
+
+        /// <summary>Social name of the natural person (PF-only).</summary>
+        [JsonProperty("socialName")]
+        public string SocialName { get; set; }
+
+        /// <summary>Sex of the natural person (PF-only).</summary>
+        [JsonProperty("sex")]
+        public Sex? Sex { get; set; }
+
+        /// <summary>Marital status of the natural person (PF-only).</summary>
+        [JsonProperty("maritalStatus")]
+        public MaritalStatus MaritalStatus { get; set; }
+
+        /// <summary>Nationality of the natural person (PF-only).</summary>
+        [JsonProperty("nationality")]
+        public Nationality Nationality { get; set; }
+
+        /// <summary>Other identification documents the natural person holds (PF-only).</summary>
+        [JsonProperty("otherDocuments")]
+        public List<OtherDocument> OtherDocuments { get; set; }
+
+        /// <summary>Passport metadata for the natural person (PF-only).</summary>
+        [JsonProperty("passport")]
+        public Passport Passport { get; set; }
+
+        /// <summary>Date the business was incorporated (PJ-only).</summary>
+        [JsonProperty("incorporationDate")]
+        public DateTime? IncorporationDate { get; set; }
+
+        /// <summary>Partners and administrators of the business (PJ-only).</summary>
+        [JsonProperty("parties")]
+        public List<BusinessParty> Parties { get; set; }
+
+        /// <summary>
+        /// Additional documents for businesses headquartered abroad and not required to register a CNPJ (PJ-only).
+        /// </summary>
+        [JsonProperty("businessOtherDocuments")]
+        public List<BusinessOtherDocument> BusinessOtherDocuments { get; set; }
+
+        /// <summary>CNPJs of the financial institutions responsible for the customer cadastro.</summary>
+        [JsonProperty("companiesCnpj")]
+        public List<string> CompaniesCnpj { get; set; }
     }
 }

--- a/Pluggy.SDK/Model/MaritalStatus.cs
+++ b/Pluggy.SDK/Model/MaritalStatus.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class MaritalStatus
+    {
+        [JsonProperty("code")]
+        public MaritalStatusCode Code { get; set; }
+
+        /// <summary>Free-text complement. Populated when Code is OTHER.</summary>
+        [JsonProperty("additionalInfo")]
+        public string AdditionalInfo { get; set; }
+    }
+
+    public enum MaritalStatusCode
+    {
+        SINGLE,
+        MARRIED,
+        WIDOWED,
+        JUDICIALLY_SEPARATED,
+        DIVORCED,
+        STABLE_UNION,
+        OTHER
+    }
+}

--- a/Pluggy.SDK/Model/Nationality.cs
+++ b/Pluggy.SDK/Model/Nationality.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class Nationality
+    {
+        [JsonProperty("hasBrazilianNationality")]
+        public bool? HasBrazilianNationality { get; set; }
+
+        [JsonProperty("otherNationalities")]
+        public List<OtherNationality> OtherNationalities { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/NationalityDocument.cs
+++ b/Pluggy.SDK/Model/NationalityDocument.cs
@@ -1,0 +1,26 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class NationalityDocument
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("issueDate")]
+        public DateTime? IssueDate { get; set; }
+
+        [JsonProperty("expirationDate")]
+        public DateTime? ExpirationDate { get; set; }
+
+        [JsonProperty("additionalInfo")]
+        public string AdditionalInfo { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/OtherDocument.cs
+++ b/Pluggy.SDK/Model/OtherDocument.cs
@@ -1,0 +1,38 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class OtherDocument
+    {
+        [JsonProperty("type")]
+        public OtherDocumentType? Type { get; set; }
+
+        /// <summary>Free-text complement. Populated when Type is OTHER.</summary>
+        [JsonProperty("typeAdditionalInfo")]
+        public string TypeAdditionalInfo { get; set; }
+
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        [JsonProperty("checkDigit")]
+        public string CheckDigit { get; set; }
+
+        /// <summary>Free-text complement, used to record the issuing authority (e.g. 'SSP/SP') when relevant.</summary>
+        [JsonProperty("additionalInfo")]
+        public string AdditionalInfo { get; set; }
+
+        [JsonProperty("expirationDate")]
+        public DateTime? ExpirationDate { get; set; }
+    }
+
+    /// <summary>Brazilian document acronyms are kept verbatim; OTHER covers any other type.</summary>
+    public enum OtherDocumentType
+    {
+        CNH,
+        RG,
+        NIF,
+        RNE,
+        OTHER
+    }
+}

--- a/Pluggy.SDK/Model/OtherNationality.cs
+++ b/Pluggy.SDK/Model/OtherNationality.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class OtherNationality
+    {
+        /// <summary>Country code in alpha3 ISO-3166 format.</summary>
+        [JsonProperty("countryCode")]
+        public string CountryCode { get; set; }
+
+        [JsonProperty("documents")]
+        public List<NationalityDocument> Documents { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/Passport.cs
+++ b/Pluggy.SDK/Model/Passport.cs
@@ -1,0 +1,21 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class Passport
+    {
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        /// <summary>Issuing country in alpha3 ISO-3166 format.</summary>
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("issueDate")]
+        public DateTime? IssueDate { get; set; }
+
+        [JsonProperty("expirationDate")]
+        public DateTime? ExpirationDate { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/PhoneNumber.cs
+++ b/Pluggy.SDK/Model/PhoneNumber.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Pluggy.SDK.Model
 {
@@ -9,6 +9,22 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("value")]
         public string Value { get; set; }
+
+        /// <summary>International dialing code (DDI). Populated when different from '55'.</summary>
+        [JsonProperty("countryCallingCode")]
+        public string CountryCallingCode { get; set; }
+
+        /// <summary>Area code (DDD) of the phone.</summary>
+        [JsonProperty("areaCode")]
+        public string AreaCode { get; set; }
+
+        /// <summary>Extension number, when part of the phone identification.</summary>
+        [JsonProperty("extension")]
+        public string Extension { get; set; }
+
+        /// <summary>Additional info related to the source phone type.</summary>
+        [JsonProperty("additionalInfo")]
+        public string AdditionalInfo { get; set; }
     }
 
     public enum PhoneNumberType

--- a/Pluggy.SDK/Model/Sex.cs
+++ b/Pluggy.SDK/Model/Sex.cs
@@ -1,0 +1,9 @@
+namespace Pluggy.SDK.Model
+{
+    public enum Sex
+    {
+        FEMALE,
+        MALE,
+        OTHER
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors the Identity additions on the API side  into the .NET SDK. All new fields are optional / nullable — existing consumers keep working unchanged, and Newtonsoft tolerates them being absent on the wire.

## What changes

### Extended classes

**`Identity`** gains 10 properties:
- PF — `SocialName`, `Sex`, `MaritalStatus`, `Nationality`, `OtherDocuments`, `Passport`
- PJ — `IncorporationDate`, `Parties`, `BusinessOtherDocuments`
- Shared — `CompaniesCnpj`

**`PhoneNumber`** gains `CountryCallingCode`, `AreaCode`, `Extension`, `AdditionalInfo`.

**`Address`** gains `District`, `IbgeTownCode`, `CountryCode`, `GeographicCoordinates`.

### New types (14)

- `Sex` enum
- `MaritalStatus` + `MaritalStatusCode` enum
- `Nationality` + `OtherNationality` + `NationalityDocument`
- `OtherDocument` + `OtherDocumentType` enum
- `Passport`
- `BusinessParty` + `BusinessPartyType` / `BusinessPartyPersonType` / `BusinessPartyDocumentType` enums
- `BusinessOtherDocument`
- `GeographicCoordinates`

Every class follows the project's existing pattern (Newtonsoft `[JsonProperty("camelCase")]` on every member, enums colocated with their parent class when one exists — matching `PhoneNumber.cs` / `Address.cs` / `IdentityRelation.cs`). Enum literals use `ALL_CAPS` for API values that ship that way (`MaritalStatusCode`, `BusinessParty*`, `Sex`) so Newtonsoft's case-insensitive name matching binds them without a custom converter.

## Out of scope

The .NET SDK has historically not exposed `Qualifications` or `FinancialRelationships`, so the new sub-fields that live under those (`EconomicActivities`, `InformedRevenue`, `PortabilitiesReceived`, `PaycheckBankLink`, `InformedPatrimony.Date`, procurator's `DocumentNumber`/`DocumentType`, etc.) are not in this PR. They need the missing parent types introduced first — better as a follow-up that also catches the .NET SDK up on the pre-existing fields.

## Test plan

- [ ] CI build (`build.yml`) — confirms `dotnet build` is clean (the new files compile, the changes to `Address`/`Identity`/`PhoneNumber` don't break anything).
- [ ] Smoke test against a deployed API 0.24 item that returns the new fields — `Identity` should deserialize with the new properties populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)