### PR TITLE
ci(release): use GitHub App token and bump action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,33 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_SECRET }}
 
-      - name: Setup .NET Core SDK 
-        uses: actions/setup-dotnet@v4
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 6.0.x
 
       - name: Semantic Release
         id: release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v6.0.0
         with:
           semantic_version: 19
           working_directory: ./Pluggy.SDK
@@ -37,7 +51,7 @@ jobs:
             @semantic-release/git@10
             @semantic-release/exec@6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUNNER_DEBUG: 1
           
       - name: 'Pack & Publish project'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary
- Switch the release commit auth from the default `GITHUB_TOKEN` to a GitHub App token (`GH_APP_ID` / `GH_APP_SECRET`), aligning with `pluggy-node`. This makes the `chore(release):` commit able to trigger downstream workflows instead of being attributed to `github-actions[bot]`.
- Declare explicit least-privilege `permissions:` on the release job (`contents`, `issues`, `pull-requests`, `id-token` — all `write`).
- Bump pinned action versions:
  - `actions/create-github-app-token` `v2` → `v3.2.0`
  - `actions/checkout` `v3` → `v6.0.2`
  - `actions/setup-dotnet` `v4` → `v5.2.0`
  - `cycjimmy/semantic-release-action` `v3` → `v6.0.0`

`semantic_version: 19` and the existing `extra_plugins` pins are kept as-is, so the cycjimmy v6 default of semantic-release 25 is overridden and the release behavior itself does not change.

## Test plan
- [ ] Confirm `GH_APP_ID` and `GH_APP_SECRET` secrets exist on the `pluggyai/pluggy-net` repo (or org) before merging.
- [ ] Confirm the GitHub App is installed on `pluggyai/pluggy-net` with `contents: write`, `pull_requests: write`, and `issues: write`.
- [ ] After merge to `master`, verify the Release workflow runs end-to-end: app token is generated, `dotnet pack` runs, the new package is pushed to NuGet, and a `chore(release): x.y.z [skip ci]` commit + GitHub Release are created.