### PR TITLE
feat(account): add reserved balance fields to bank data

### DIFF
--- a/Pluggy.SDK/Model/Account.cs
+++ b/Pluggy.SDK/Model/Account.cs
@@ -67,6 +67,12 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("unarrangedOverdraftAmount")]
         public double? UnarrangedOverdraftAmount { get; set; }
+
+        [JsonProperty("hasReservedBalance")]
+        public bool? HasReservedBalance { get; set; }
+
+        [JsonProperty("reservedBalances")]
+        public ICollection<ReservedBalance> ReservedBalances { get; set; }
     }
 
     public class CreditAccount

--- a/Pluggy.SDK/Model/ReservedBalance.cs
+++ b/Pluggy.SDK/Model/ReservedBalance.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    public class ReservedBalance
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("identification")]
+        public string Identification { get; set; }
+
+        [JsonProperty("amounts")]
+        public ICollection<ReservedBalanceAmount> Amounts { get; set; }
+    }
+
+    public class ReservedBalanceAmount
+    {
+        [JsonProperty("amount")]
+        public double Amount { get; set; }
+
+        [JsonProperty("currencyCode")]
+        public CurrencyCode CurrencyCode { get; set; }
+
+        [JsonProperty("remuneration", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public ReservedBalanceRemuneration Remuneration { get; set; }
+    }
+
+    public class ReservedBalanceRemuneration
+    {
+        [JsonProperty("preFixedRate")]
+        public double? PreFixedRate { get; set; }
+
+        [JsonProperty("postFixedIndexerPercentage")]
+        public double? PostFixedIndexerPercentage { get; set; }
+
+        [JsonProperty("rateType")]
+        public string RateType { get; set; }
+
+        [JsonProperty("indexer")]
+        public string Indexer { get; set; }
+
+        [JsonProperty("calculation")]
+        public string Calculation { get; set; }
+
+        [JsonProperty("ratePeriodicity")]
+        public string RatePeriodicity { get; set; }
+
+        [JsonProperty("indexerAdditionalInfo")]
+        public string IndexerAdditionalInfo { get; set; }
+    }
+}


### PR DESCRIPTION
## What

Adds the reserved-balance ("saldo reservado") fields to `BankAccount`, syncing the .NET SDK with the current API spec.

### Added to `BankAccount` (Account.cs)
- `bool? HasReservedBalance`
- `ICollection<ReservedBalance> ReservedBalances`

### New models (Model/ReservedBalance.cs)
- `ReservedBalance`
- `ReservedBalanceAmount`
- `ReservedBalanceRemuneration`

All additive (new optional fields), so it is backward-compatible.

## Validation
- ⚠️ Not compiled locally (no .NET SDK installed in the dev environment). Changes follow the existing `BankAccount`/`CreditAccount` patterns in `Account.cs`, reuse the existing `CurrencyCode` enum, and the SDK-style csproj auto-includes the new file. CI build will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)