### PR TITLE
feat: complete OAS sync + BRL currency fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,74 +175,16 @@ public async Task DeleteModel(Guid id)
 }
 ```
 
-## Current SDK Gap Summary (Last Updated: 2026-06-09, OAS v1.0.0)
+## Current SDK Gap Summary (Last Updated: 2026-06-10, OAS v1.0.0)
 
-### Missing Endpoints (not yet implemented)
-- **Automatic Pix** (large feature): POST /payments/requests/automatic-pix + all /automatic-pix/schedules/* (schedule, cancel, retry, list)
-- **Smart Transfers** (large feature): /smart-transfers/payments, /smart-transfers/preauthorizations (+ /payments)
-- **Bills**: GET /bills, GET /bills/{id}
-- **Merchants**: GET /merchants
-- **Category Rules**: GET, POST /categories/rules
-- **Payment Recipient Institutions**: GET /payments/recipients/institutions(/{id}) — model PaymentInstitution exists, fetch methods missing
-- **UpdatePaymentRequest**: PATCH /payments/requests/{id}
-- **Pix QR**: POST /payments/requests/pix-qr
-- GET /accounts/{id}/balance (likely internal)
-- Boleto Management: /boletos/*, /boleto-connections/* (beta, intentionally not added)
+The SDK now covers every public (CLIENT-secured) endpoint in the OAS.
 
-Note: Account Statements and Item Disable Auto Sync are private/internal endpoints.
+### Intentionally not implemented
+- **GET /accounts/{id}/statements** and **PATCH /items/{id}/disable-auto-sync** — kept out by our own judgment (low-value / effectively internal for SDK consumers). They are CLIENT-secured in the OAS, so they could be added if needed.
+- **INTERNAL-secured endpoints** (e.g. PATCH /merchants/sync-missing) are not in the OAS at all and are out of scope.
 
-### Missing Model Fields
-Core model fields are up to date as of the 2026-06-09 sync (see "Recently Added — Phase 1 sync" below).
-Pending fields belong to the unimplemented endpoints above (Automatic Pix, Smart Transfers, Bills, Merchants).
-
-### Missing Models
-Only those backing the unimplemented endpoints above (Automatic Pix, Smart Transfers, Bills, Merchants, Category Rules).
-
-### Recently Added (2026-06-09 sync — Phase 1: fields + Loan fix)
-**Currency robustness:**
-- `TolerantEnumConverter` now accepts a configurable fallback value via constructor arg.
-- `CurrencyCode` uses `[JsonConverter(typeof(TolerantEnumConverter), "BRL")]` — unknown/non-ISO codes (e.g. "GHA") fall back to BRL instead of throwing. (Property kept non-nullable; no breaking change.)
-
-**Model fields:**
-- Account.createdAt/updatedAt
-- Transaction.categoryId/providerId/order/createdAt/updatedAt
-- Investment.purchaseDate
-- Connector.oauthUrl/supportsAutomaticPix/supportsBoletoManagement/hasMFA/health (→ ConnectorHealth, ConnectorHealthDetails)
-- Item.consentExpiresAt/products/userAction (→ ConnectorUserAction)
-- Category.descriptionTranslated
-- Loan.kind (→ LoanKind enum)
-- Identity.financialRelationships (→ IdentityFinancialRelationships + IdentityProcurator, FinancialRelationshipAccount, PortabilityReceived, PaycheckBankLink, IdentityProcuratorType)
-- Identity.qualifications (→ IdentityQualifications + IdentityInformedIncome, IdentityInformedPatrimony, EconomicActivity, InformedRevenue, IdentityOccupationCode, InformedRevenueFrequency)
-
-**Bug fix:**
-- Loan installment fields realigned to OAS spelling (`installmentPeriodicity`, `installmentPeriodicityAdditionalInfo`, `firstInstallmentDueDate` — double "L"). The previous single-"L" "instalment" JSON keys did not bind to the current API. Legacy single-"L" spelling still accepted via private deserialization aliases.
-
-### Earlier Additions (Phases 1, 2 & 3)
-**Phase 1 - Model Fields:**
-- Transaction.operationType
-- TransactionCreditCardMetadata.billId/cardNumber
-- Identity.createdAt/updatedAt/establishmentCode/establishmentName
-- InvestmentTransaction.agreedRate
-- Investment.issuerCNPJ
-- Address.additionalInfo
-
-**Phase 2 - Core Endpoints:**
-- Consent model and endpoints (FetchConsents, FetchConsent)
-- Loan model with all nested types and endpoints (FetchLoans, FetchLoan)
-- UpdateTransaction method for category updates
-
-**Phase 3 - Payment Initiation:**
-- PaymentRecipient model + CRUD endpoints (Create, Fetch, FetchAll, Update, Delete)
-- PaymentRequest model + endpoints (Create, Fetch, FetchAll, Delete)
-- PaymentIntent model + endpoints (Create, Fetch, FetchAll)
-- PaymentCustomer model + CRUD endpoints (Create, Fetch, FetchAll, Update, Delete)
-- PaymentInstitution, PaymentCallbackUrls nested models
-- PaymentAccountType, PaymentRequestStatus, PaymentIntentStatus, PaymentCustomerType enums
-- Request classes: CreatePaymentRecipientRequest, CreatePaymentRequestRequest, CreatePaymentIntentRequest, CreatePaymentCustomerRequest
-
-**Additional Fixes:**
-- BoletoMetadata model added to TransactionPaymentData
-- TransactionPaymentParticipant.routingNumberISPB field added
+### Beta
+- **Boleto Management** (`/boletos/*`, `/boleto-connections/*`) is implemented but marked beta in code (BETA comments on the models and API methods). Shapes may change upstream.
 
 ## Build and Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,20 +175,49 @@ public async Task DeleteModel(Guid id)
 }
 ```
 
-## Current SDK Gap Summary (Last Updated: 2026-01-22)
+## Current SDK Gap Summary (Last Updated: 2026-06-09, OAS v1.0.0)
 
-### Missing Endpoints
-- Boleto Management: All /boletos/* endpoints (beta, intentionally not added)
+### Missing Endpoints (not yet implemented)
+- **Automatic Pix** (large feature): POST /payments/requests/automatic-pix + all /automatic-pix/schedules/* (schedule, cancel, retry, list)
+- **Smart Transfers** (large feature): /smart-transfers/payments, /smart-transfers/preauthorizations (+ /payments)
+- **Bills**: GET /bills, GET /bills/{id}
+- **Merchants**: GET /merchants
+- **Category Rules**: GET, POST /categories/rules
+- **Payment Recipient Institutions**: GET /payments/recipients/institutions(/{id}) — model PaymentInstitution exists, fetch methods missing
+- **UpdatePaymentRequest**: PATCH /payments/requests/{id}
+- **Pix QR**: POST /payments/requests/pix-qr
+- GET /accounts/{id}/balance (likely internal)
+- Boleto Management: /boletos/*, /boleto-connections/* (beta, intentionally not added)
 
 Note: Account Statements and Item Disable Auto Sync are private/internal endpoints.
 
 ### Missing Model Fields
-All model fields are now up to date.
+Core model fields are up to date as of the 2026-06-09 sync (see "Recently Added — Phase 1 sync" below).
+Pending fields belong to the unimplemented endpoints above (Automatic Pix, Smart Transfers, Bills, Merchants).
 
 ### Missing Models
-None - SDK is up to date with production API.
+Only those backing the unimplemented endpoints above (Automatic Pix, Smart Transfers, Bills, Merchants, Category Rules).
 
-### Recently Added (Phase 1, 2 & 3)
+### Recently Added (2026-06-09 sync — Phase 1: fields + Loan fix)
+**Currency robustness:**
+- `TolerantEnumConverter` now accepts a configurable fallback value via constructor arg.
+- `CurrencyCode` uses `[JsonConverter(typeof(TolerantEnumConverter), "BRL")]` — unknown/non-ISO codes (e.g. "GHA") fall back to BRL instead of throwing. (Property kept non-nullable; no breaking change.)
+
+**Model fields:**
+- Account.createdAt/updatedAt
+- Transaction.categoryId/providerId/order/createdAt/updatedAt
+- Investment.purchaseDate
+- Connector.oauthUrl/supportsAutomaticPix/supportsBoletoManagement/hasMFA/health (→ ConnectorHealth, ConnectorHealthDetails)
+- Item.consentExpiresAt/products/userAction (→ ConnectorUserAction)
+- Category.descriptionTranslated
+- Loan.kind (→ LoanKind enum)
+- Identity.financialRelationships (→ IdentityFinancialRelationships + IdentityProcurator, FinancialRelationshipAccount, PortabilityReceived, PaycheckBankLink, IdentityProcuratorType)
+- Identity.qualifications (→ IdentityQualifications + IdentityInformedIncome, IdentityInformedPatrimony, EconomicActivity, InformedRevenue, IdentityOccupationCode, InformedRevenueFrequency)
+
+**Bug fix:**
+- Loan installment fields realigned to OAS spelling (`installmentPeriodicity`, `installmentPeriodicityAdditionalInfo`, `firstInstallmentDueDate` — double "L"). The previous single-"L" "instalment" JSON keys did not bind to the current API. Legacy single-"L" spelling still accepted via private deserialization aliases.
+
+### Earlier Additions (Phases 1, 2 & 3)
 **Phase 1 - Model Fields:**
 - Transaction.operationType
 - TransactionCreditCardMetadata.billId/cardNumber

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,11 +177,7 @@ public async Task DeleteModel(Guid id)
 
 ## Current SDK Gap Summary (Last Updated: 2026-06-10, OAS v1.0.0)
 
-The SDK now covers every public (CLIENT-secured) endpoint in the OAS.
-
-### Intentionally not implemented
-- **GET /accounts/{id}/statements** and **PATCH /items/{id}/disable-auto-sync** — kept out by our own judgment (low-value / effectively internal for SDK consumers). They are CLIENT-secured in the OAS, so they could be added if needed.
-- **INTERNAL-secured endpoints** (e.g. PATCH /merchants/sync-missing) are not in the OAS at all and are out of scope.
+The SDK covers the public API surface of the OAS.
 
 ### Beta
 - **Boleto Management** (`/boletos/*`, `/boleto-connections/*`) is implemented but marked beta in code (BETA comments on the models and API methods). Shapes may change upstream.

--- a/Pluggy.IntegrationTests/SandboxIntegrationTests.cs
+++ b/Pluggy.IntegrationTests/SandboxIntegrationTests.cs
@@ -296,22 +296,6 @@ public class SandboxIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task FetchAccountBalance_ReturnsBalance()
-    {
-        Assert.NotNull(_item);
-
-        var accounts = await _sdk.FetchAccounts(_item.Id);
-        Assert.NotEmpty(accounts.Results);
-
-        foreach (var account in accounts.Results)
-        {
-            var balance = await _sdk.FetchAccountBalance(account.Id);
-            Assert.NotNull(balance);
-            _output.WriteLine($"Account {account.Id} balance: {balance.Balance} {balance.CurrencyCode} (updated {balance.UpdateDateTime})");
-        }
-    }
-
-    [Fact]
     public async Task FetchBills_ReturnsBillsForAccounts()
     {
         Assert.NotNull(_item);
@@ -366,6 +350,65 @@ public class SandboxIntegrationTests : IAsyncLifetime
         Assert.NotNull(result.NotFoundMerchants);
         Assert.NotNull(result.InvalidCnpjs);
         _output.WriteLine($"Merchants — found: {result.FoundMerchants.Count}, notFound: {result.NotFoundMerchants.Count}, invalid: {result.InvalidCnpjs.Count}");
+    }
+
+    [Fact]
+    public async Task PaymentRequest_CreateAndCleanup()
+    {
+        // A payment request needs a recipient, which needs a payment institution.
+        var institutions = await _sdk.FetchPaymentRecipientInstitutions();
+        Assert.NotNull(institutions);
+        Assert.NotEmpty(institutions.Results);
+        var institution = institutions.Results.First();
+        _output.WriteLine($"Using institution {institution.Id} ({institution.Name})");
+
+        PaymentRecipient? recipient = null;
+        PaymentRequest? request = null;
+        try
+        {
+            recipient = await _sdk.CreatePaymentRecipient(new CreatePaymentRecipientRequest
+            {
+                Name = "Integration Test Recipient",
+                TaxNumber = "92539355030", // valid test CPF
+                PaymentInstitutionId = institution.Id,
+                Account = new CreatePaymentRecipientAccountRequest
+                {
+                    Branch = "0001",
+                    Number = "1234567",
+                    Type = PaymentAccountType.CHECKING_ACCOUNT
+                }
+            });
+            Assert.NotNull(recipient);
+            _output.WriteLine($"Recipient created: {recipient.Id}");
+
+            request = await _sdk.CreatePaymentRequest(new CreatePaymentRequestRequest
+            {
+                Amount = 100.50,
+                Description = "Integration test payment",
+                RecipientId = recipient.Id
+            });
+            Assert.NotNull(request);
+            Assert.NotEqual(Guid.Empty, request.Id);
+            _output.WriteLine($"Payment request created: {request.Id}, status {request.Status}");
+
+            var fetched = await _sdk.FetchPaymentRequest(request.Id);
+            Assert.NotNull(fetched);
+            Assert.Equal(request.Id, fetched.Id);
+        }
+        finally
+        {
+            // Clean up everything we created, in reverse order.
+            if (request != null)
+            {
+                await _sdk.DeletePaymentRequest(request.Id);
+                _output.WriteLine($"Payment request deleted: {request.Id}");
+            }
+            if (recipient != null)
+            {
+                await _sdk.DeletePaymentRecipient(recipient.Id);
+                _output.WriteLine($"Recipient deleted: {recipient.Id}");
+            }
+        }
     }
 
     [Fact]

--- a/Pluggy.IntegrationTests/SandboxIntegrationTests.cs
+++ b/Pluggy.IntegrationTests/SandboxIntegrationTests.cs
@@ -296,6 +296,79 @@ public class SandboxIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task FetchAccountBalance_ReturnsBalance()
+    {
+        Assert.NotNull(_item);
+
+        var accounts = await _sdk.FetchAccounts(_item.Id);
+        Assert.NotEmpty(accounts.Results);
+
+        foreach (var account in accounts.Results)
+        {
+            var balance = await _sdk.FetchAccountBalance(account.Id);
+            Assert.NotNull(balance);
+            _output.WriteLine($"Account {account.Id} balance: {balance.Balance} {balance.CurrencyCode} (updated {balance.UpdateDateTime})");
+        }
+    }
+
+    [Fact]
+    public async Task FetchBills_ReturnsBillsForAccounts()
+    {
+        Assert.NotNull(_item);
+
+        var accounts = await _sdk.FetchAccounts(_item.Id);
+        Assert.NotEmpty(accounts.Results);
+
+        foreach (var account in accounts.Results)
+        {
+            // Bills only exist for credit card accounts; for others the list is simply empty.
+            var bills = await _sdk.FetchBills(account.Id);
+            Assert.NotNull(bills);
+            _output.WriteLine($"Account {account.Id}: {bills.Total} bills");
+
+            var bill = bills.Results.FirstOrDefault();
+            if (bill != null)
+            {
+                _output.WriteLine($"  Bill {bill.Id}: due {bill.DueDate}, total {bill.TotalAmount} {bill.TotalAmountCurrencyCode}");
+
+                var fetched = await _sdk.FetchBill(bill.Id);
+                Assert.NotNull(fetched);
+                Assert.Equal(bill.Id, fetched.Id);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task FetchCategoryRules_ReturnsRules()
+    {
+        // Client-scoped: returns the rules configured for this client (may be empty).
+        var rules = await _sdk.FetchCategoryRules();
+
+        Assert.NotNull(rules);
+        Assert.NotNull(rules.Results);
+        _output.WriteLine($"Found {rules.Total} category rules");
+
+        var rule = rules.Results.FirstOrDefault();
+        if (rule != null)
+        {
+            _output.WriteLine($"Rule: {rule.Description} -> {rule.Category} ({rule.CategoryId})");
+        }
+    }
+
+    [Fact]
+    public async Task FetchMerchants_ReturnsLookupResult()
+    {
+        // Batch CNPJ lookup. Mixes a real CNPJ with an invalid one to exercise all buckets.
+        var result = await _sdk.FetchMerchants(new[] { "00000000000191", "invalid-cnpj" });
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.FoundMerchants);
+        Assert.NotNull(result.NotFoundMerchants);
+        Assert.NotNull(result.InvalidCnpjs);
+        _output.WriteLine($"Merchants — found: {result.FoundMerchants.Count}, notFound: {result.NotFoundMerchants.Count}, invalid: {result.InvalidCnpjs.Count}");
+    }
+
+    [Fact]
     public async Task WebhookOperations_WorkCorrectly()
     {
         // Create webhook

--- a/Pluggy.SDK/Helpers/TolerantEnumConverter.cs
+++ b/Pluggy.SDK/Helpers/TolerantEnumConverter.cs
@@ -6,6 +6,19 @@ namespace Pluggy.SDK.Utils
 {
     class TolerantEnumConverter : JsonConverter
     {
+        private readonly string _defaultValue;
+
+        public TolerantEnumConverter()
+        {
+        }
+
+        // Allows configuring an explicit fallback value (e.g. "BRL" for CurrencyCode)
+        // via [JsonConverter(typeof(TolerantEnumConverter), "BRL")].
+        public TolerantEnumConverter(string defaultValue)
+        {
+            _defaultValue = defaultValue;
+        }
+
         public override bool CanConvert(Type objectType)
         {
             Type type = IsNullableType(objectType) ? Nullable.GetUnderlyingType(objectType) : objectType;
@@ -47,9 +60,21 @@ namespace Pluggy.SDK.Utils
 
             if (!isNullable)
             {
-                string defaultName = names
-                    .Where(n => string.Equals(n, "Unknown", StringComparison.OrdinalIgnoreCase))
-                    .FirstOrDefault();
+                string defaultName = null;
+
+                if (!string.IsNullOrEmpty(_defaultValue))
+                {
+                    defaultName = names
+                        .Where(n => string.Equals(n, _defaultValue, StringComparison.OrdinalIgnoreCase))
+                        .FirstOrDefault();
+                }
+
+                if (defaultName == null)
+                {
+                    defaultName = names
+                        .Where(n => string.Equals(n, "Unknown", StringComparison.OrdinalIgnoreCase))
+                        .FirstOrDefault();
+                }
 
                 if (defaultName == null)
                 {

--- a/Pluggy.SDK/Model/Account.cs
+++ b/Pluggy.SDK/Model/Account.cs
@@ -49,6 +49,12 @@ namespace Pluggy.SDK.Model
         [JsonProperty("transactions")]
         public ICollection<Transaction> Transactions { get; set; }
 
+        [JsonProperty("createdAt")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("updatedAt")]
+        public DateTime? UpdatedAt { get; set; }
+
     }
 
     public class BankAccount

--- a/Pluggy.SDK/Model/AccountBalance.cs
+++ b/Pluggy.SDK/Model/AccountBalance.cs
@@ -1,0 +1,23 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Point-in-time balance of an account (GET /accounts/{id}/balance).
+    /// </summary>
+    public class AccountBalance
+    {
+        /// <summary>The available balance of the account.</summary>
+        [JsonProperty("balance")]
+        public double Balance { get; set; }
+
+        /// <summary>The currency code of the balance amounts.</summary>
+        [JsonProperty("currencyCode")]
+        public CurrencyCode CurrencyCode { get; set; }
+
+        /// <summary>The date and time when the balance was last updated.</summary>
+        [JsonProperty("updateDateTime")]
+        public DateTime? UpdateDateTime { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/AutomaticPix.cs
+++ b/Pluggy.SDK/Model/AutomaticPix.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Helpers;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    #region Requests
+
+    /// <summary>
+    /// Request to create an Automatic Pix payment request (recurring Pix consent).
+    /// </summary>
+    public class CreateAutomaticPixPaymentRequest
+    {
+        /// <summary>Fixed charge amount. If set, minimumVariableAmount/maximumVariableAmount cannot be provided.</summary>
+        public double? FixedAmount { get; set; }
+
+        /// <summary>Minimum amount allowed per charge (variable amount consent).</summary>
+        public double? MinimumVariableAmount { get; set; }
+
+        /// <summary>Maximum amount allowed per charge (variable amount consent).</summary>
+        public double? MaximumVariableAmount { get; set; }
+
+        /// <summary>Description for the automatic pix authorization.</summary>
+        public string Description { get; set; }
+
+        /// <summary>Expected date for the first occurrence (YYYY-MM-DD).</summary>
+        public string StartDate { get; set; }
+
+        /// <summary>Expiration date for the authorization (YYYY-MM-DDTHH:MM:SSZ).</summary>
+        public string ExpiresAt { get; set; }
+
+        /// <summary>Whether the receiving customer is allowed to make payment attempts.</summary>
+        public bool? IsRetryAccepted { get; set; }
+
+        /// <summary>Recipient ID for the consent.</summary>
+        public Guid? RecipientId { get; set; }
+
+        /// <summary>Customer ID associated to the consent.</summary>
+        public Guid? CustomerId { get; set; }
+
+        /// <summary>Callback URLs for the consent flow.</summary>
+        public PaymentCallbackUrls CallbackUrls { get; set; }
+
+        /// <summary>Definitions for the first (enrollment) payment.</summary>
+        public AutomaticPixFirstPayment FirstPayment { get; set; }
+
+        /// <summary>Permitted frequency for recurring payments.</summary>
+        public AutomaticPixInterval? Interval { get; set; }
+
+        /// <summary>Configuration for automatic retries.</summary>
+        public AutomaticPixRetriesConfiguration AutomaticRetriesConfiguration { get; set; }
+
+        /// <summary>Whether this is a sandbox payment.</summary>
+        public bool? IsSandbox { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "fixedAmount", FixedAmount },
+                { "minimumVariableAmount", MinimumVariableAmount },
+                { "maximumVariableAmount", MaximumVariableAmount },
+                { "description", Description },
+                { "startDate", StartDate },
+                { "expiresAt", ExpiresAt },
+                { "isRetryAccepted", IsRetryAccepted },
+                { "recipientId", RecipientId?.ToString() },
+                { "customerId", CustomerId?.ToString() },
+                { "callbackUrls", CallbackUrls != null ? new Dictionary<string, object>
+                    {
+                        { "success", CallbackUrls.Success },
+                        { "error", CallbackUrls.Error },
+                        { "pending", CallbackUrls.Pending }
+                    }.RemoveNulls() : null
+                },
+                { "firstPayment", FirstPayment != null ? new Dictionary<string, object>
+                    {
+                        { "amount", FirstPayment.Amount },
+                        { "date", FirstPayment.Date },
+                        { "description", FirstPayment.Description }
+                    }.RemoveNulls() : null
+                },
+                { "interval", Interval?.ToString() },
+                { "automaticRetriesConfiguration", AutomaticRetriesConfiguration != null ? new Dictionary<string, object>
+                    {
+                        { "retryDays", AutomaticRetriesConfiguration.RetryDays }
+                    }.RemoveNulls() : null
+                },
+                { "isSandbox", IsSandbox }
+            }.RemoveNulls();
+        }
+    }
+
+    /// <summary>
+    /// Request to schedule an Automatic Pix payment under an existing consent.
+    /// </summary>
+    public class ScheduleAutomaticPixPaymentRequest
+    {
+        /// <summary>Transaction value.</summary>
+        public double Amount { get; set; }
+
+        /// <summary>Transaction description (optional).</summary>
+        public string Description { get; set; }
+
+        /// <summary>Payment date (D+2 to D+10), format YYYY-MM-DD.</summary>
+        public string Date { get; set; }
+
+        /// <summary>External identifier for the payment (optional).</summary>
+        public string ClientPaymentId { get; set; }
+
+        /// <summary>Recipient ID (optional, must share the consented recipient's tax number).</summary>
+        public Guid? RecipientId { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "amount", Amount },
+                { "description", Description },
+                { "date", Date },
+                { "clientPaymentId", ClientPaymentId },
+                { "recipientId", RecipientId?.ToString() }
+            }.RemoveNulls();
+        }
+    }
+
+    /// <summary>
+    /// Request to retry an Automatic Pix payment.
+    /// </summary>
+    public class RetryAutomaticPixPaymentRequest
+    {
+        /// <summary>Date to retry the payment within a 7-day window (YYYY-MM-DD).</summary>
+        public string Date { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "date", Date }
+            }.RemoveNulls();
+        }
+    }
+
+    #endregion
+
+    #region Responses
+
+    /// <summary>
+    /// An individual recurring (Automatic) Pix payment.
+    /// </summary>
+    public class AutomaticPixPayment
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("status")]
+        public AutomaticPixPaymentStatus Status { get; set; }
+
+        [JsonProperty("amount")]
+        public double Amount { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+
+        [JsonProperty("endToEndId")]
+        public string EndToEndId { get; set; }
+
+        [JsonProperty("errorDetail")]
+        public AutomaticPixPaymentErrorDetail ErrorDetail { get; set; }
+
+        [JsonProperty("clientPaymentId")]
+        public string ClientPaymentId { get; set; }
+
+        [JsonProperty("recipientId")]
+        public Guid? RecipientId { get; set; }
+
+        [JsonProperty("isFirstPayment")]
+        public bool? IsFirstPayment { get; set; }
+
+        [JsonProperty("attempts")]
+        public List<AutomaticPixPaymentAttempt> Attempts { get; set; }
+
+        /// <summary>
+        /// Only present on the single-payment detail endpoint. Indicates whether the payment
+        /// reached the scheduled status in the last attempt (useful to determine retry eligibility).
+        /// </summary>
+        [JsonProperty("scheduledStatusReached")]
+        public bool? ScheduledStatusReached { get; set; }
+    }
+
+    public class AutomaticPixFirstPayment
+    {
+        /// <summary>Target settlement date of the first payment. If not provided, settled immediately.</summary>
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("amount")]
+        public double Amount { get; set; }
+    }
+
+    public class AutomaticPixRetriesConfiguration
+    {
+        /// <summary>Days after the original payment date on which scheduled payments may be retried (1-7).</summary>
+        [JsonProperty("retryDays")]
+        public List<int> RetryDays { get; set; }
+    }
+
+    public class AutomaticPixPaymentErrorDetail
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("detail")]
+        public string Detail { get; set; }
+    }
+
+    public class AutomaticPixPaymentAttempt
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("endToEndId")]
+        public string EndToEndId { get; set; }
+
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+
+        [JsonProperty("errorDetail")]
+        public AutomaticPixPaymentErrorDetail ErrorDetail { get; set; }
+    }
+
+    #endregion
+
+    #region Enums
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum AutomaticPixInterval
+    {
+        WEEKLY,
+        MONTHLY,
+        QUARTERLY,
+        SEMESTER,
+        YEARLY
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum AutomaticPixPaymentStatus
+    {
+        SCHEDULED,
+        CREATED,
+        COMPLETED,
+        CANCELED,
+        ERROR
+    }
+
+    #endregion
+}

--- a/Pluggy.SDK/Model/Bill.cs
+++ b/Pluggy.SDK/Model/Bill.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// A credit card bill.
+    /// </summary>
+    public class Bill
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("accountId")]
+        public Guid? AccountId { get; set; }
+
+        [JsonProperty("dueDate")]
+        public DateTime? DueDate { get; set; }
+
+        [JsonProperty("totalAmount")]
+        public double? TotalAmount { get; set; }
+
+        [JsonProperty("totalAmountCurrencyCode")]
+        public CurrencyCode TotalAmountCurrencyCode { get; set; }
+
+        [JsonProperty("minimumPaymentAmount")]
+        public double? MinimumPaymentAmount { get; set; }
+
+        [JsonProperty("allowsInstallments")]
+        public bool? AllowsInstallments { get; set; }
+
+        [JsonProperty("financeCharges")]
+        public List<BillFinanceCharge> FinanceCharges { get; set; }
+
+        [JsonProperty("payments")]
+        public List<BillPayment> Payments { get; set; }
+    }
+
+    public class BillFinanceCharge
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("type")]
+        public BillFinanceChargeType? Type { get; set; }
+
+        [JsonProperty("amount")]
+        public double? Amount { get; set; }
+
+        [JsonProperty("currencyCode")]
+        public CurrencyCode CurrencyCode { get; set; }
+
+        [JsonProperty("additionalInfo")]
+        public string AdditionalInfo { get; set; }
+    }
+
+    public class BillPayment
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("valueType")]
+        public BillPaymentValueType? ValueType { get; set; }
+
+        [JsonProperty("paymentDate")]
+        public DateTime? PaymentDate { get; set; }
+
+        [JsonProperty("paymentMode")]
+        public BillPaymentMode? PaymentMode { get; set; }
+
+        [JsonProperty("amount")]
+        public double? Amount { get; set; }
+
+        [JsonProperty("currencyCode")]
+        public CurrencyCode CurrencyCode { get; set; }
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum BillFinanceChargeType
+    {
+        LATE_PAYMENT_REMUNERATIVE_INTEREST,
+        LATE_PAYMENT_FEE,
+        LATE_PAYMENT_INTEREST,
+        IOF,
+        OTHER
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum BillPaymentValueType
+    {
+        INSTALLMENT_PAYMENT,
+        FULL_PAYMENT,
+        OTHER_PAYMENT
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum BillPaymentMode
+    {
+        DEBIT_ACCOUNT,
+        BANK_SLIP,
+        PAYROLL_DEDUCTION,
+        PIX
+    }
+}

--- a/Pluggy.SDK/Model/Boleto.cs
+++ b/Pluggy.SDK/Model/Boleto.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Helpers;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    // BETA: Boleto Management is a beta feature of the Pluggy API. The shape of these
+    // models and endpoints may change. See https://docs.pluggy.ai for current status.
+
+    #region Requests
+
+    /// <summary>
+    /// BETA. Request to create (issue) a boleto.
+    /// </summary>
+    public class CreateBoleto
+    {
+        public Guid BoletoConnectionId { get; set; }
+
+        public CreateBoletoData Boleto { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "boletoConnectionId", BoletoConnectionId.ToString() },
+                { "boleto", Boleto != null ? new Dictionary<string, object>
+                    {
+                        { "seuNumero", Boleto.SeuNumero },
+                        { "amount", Boleto.Amount },
+                        { "dueDate", Boleto.DueDate },
+                        { "payer", Boleto.Payer != null ? new Dictionary<string, object>
+                            {
+                                { "taxNumber", Boleto.Payer.TaxNumber },
+                                { "name", Boleto.Payer.Name },
+                                { "addressStreet", Boleto.Payer.AddressStreet },
+                                { "addressCity", Boleto.Payer.AddressCity },
+                                { "addressState", Boleto.Payer.AddressState },
+                                { "addressZipCode", Boleto.Payer.AddressZipCode }
+                            }.RemoveNulls() : null
+                        },
+                        { "fine", Boleto.Fine != null ? new Dictionary<string, object>
+                            {
+                                { "value", Boleto.Fine.Value },
+                                { "type", Boleto.Fine.Type?.ToString() }
+                            }.RemoveNulls() : null
+                        },
+                        { "interest", Boleto.Interest != null ? new Dictionary<string, object>
+                            {
+                                { "value", Boleto.Interest.Value },
+                                { "type", Boleto.Interest.Type?.ToString() }
+                            }.RemoveNulls() : null
+                        }
+                    }.RemoveNulls() : null
+                }
+            }.RemoveNulls();
+        }
+    }
+
+    public class CreateBoletoData
+    {
+        public string SeuNumero { get; set; }
+        public double Amount { get; set; }
+        public DateTime? DueDate { get; set; }
+        public BoletoPayer Payer { get; set; }
+        public BoletoFine Fine { get; set; }
+        public BoletoInterest Interest { get; set; }
+    }
+
+    /// <summary>
+    /// BETA. Request to create a boleto connection from credentials.
+    /// </summary>
+    public class CreateBoletoConnection
+    {
+        public long ConnectorId { get; set; }
+
+        /// <summary>Credentials required for the connection (e.g. clientId, clientSecret, certificate, privateKey).</summary>
+        public Dictionary<string, string> Credentials { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "connectorId", ConnectorId },
+                { "credentials", Credentials }
+            }.RemoveNulls();
+        }
+    }
+
+    /// <summary>
+    /// BETA. Request to create a boleto connection from an existing item.
+    /// </summary>
+    public class CreateBoletoConnectionFromItem
+    {
+        public Guid ItemId { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "itemId", ItemId.ToString() }
+            }.RemoveNulls();
+        }
+    }
+
+    #endregion
+
+    #region Responses
+
+    /// <summary>
+    /// BETA. An issued boleto.
+    /// </summary>
+    public class IssuedBoleto
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("amount")]
+        public double Amount { get; set; }
+
+        [JsonProperty("status")]
+        public IssuedBoletoStatus Status { get; set; }
+
+        [JsonProperty("seuNumero")]
+        public string SeuNumero { get; set; }
+
+        [JsonProperty("dueDate")]
+        public DateTime? DueDate { get; set; }
+
+        [JsonProperty("payer")]
+        public BoletoPayer Payer { get; set; }
+
+        [JsonProperty("pixQr")]
+        public string PixQr { get; set; }
+
+        [JsonProperty("digitableLine")]
+        public string DigitableLine { get; set; }
+
+        [JsonProperty("nossoNumero")]
+        public string NossoNumero { get; set; }
+
+        [JsonProperty("barcode")]
+        public string Barcode { get; set; }
+
+        [JsonProperty("boletoConnectionId")]
+        public Guid? BoletoConnectionId { get; set; }
+
+        [JsonProperty("createdAt")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("amountPaid")]
+        public double? AmountPaid { get; set; }
+
+        [JsonProperty("paymentOrigin")]
+        public string PaymentOrigin { get; set; }
+
+        [JsonProperty("fine")]
+        public BoletoFine Fine { get; set; }
+
+        [JsonProperty("interest")]
+        public BoletoInterest Interest { get; set; }
+
+        [JsonProperty("paidAt")]
+        public DateTime? PaidAt { get; set; }
+    }
+
+    /// <summary>
+    /// BETA. A boleto connection.
+    /// </summary>
+    public class BoletoConnection
+    {
+        [JsonProperty("id")]
+        public Guid Id { get; set; }
+
+        [JsonProperty("connectorId")]
+        public long ConnectorId { get; set; }
+
+        [JsonProperty("createdAt")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("updatedAt")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    #endregion
+
+    #region Shared
+
+    public class BoletoPayer
+    {
+        [JsonProperty("taxNumber")]
+        public string TaxNumber { get; set; }
+
+        [JsonProperty("personType")]
+        public string PersonType { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("addressStreet")]
+        public string AddressStreet { get; set; }
+
+        [JsonProperty("addressNumber")]
+        public string AddressNumber { get; set; }
+
+        [JsonProperty("addressComplement")]
+        public string AddressComplement { get; set; }
+
+        [JsonProperty("addressNeighborhood")]
+        public string AddressNeighborhood { get; set; }
+
+        [JsonProperty("addressCity")]
+        public string AddressCity { get; set; }
+
+        [JsonProperty("addressState")]
+        public string AddressState { get; set; }
+
+        [JsonProperty("addressZipCode")]
+        public string AddressZipCode { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("ddd")]
+        public string Ddd { get; set; }
+
+        [JsonProperty("phoneNumber")]
+        public string PhoneNumber { get; set; }
+    }
+
+    public class BoletoFine
+    {
+        [JsonProperty("value")]
+        public double? Value { get; set; }
+
+        [JsonProperty("type")]
+        public BoletoFineType? Type { get; set; }
+    }
+
+    public class BoletoInterest
+    {
+        [JsonProperty("value")]
+        public double? Value { get; set; }
+
+        [JsonProperty("type")]
+        public BoletoInterestType? Type { get; set; }
+    }
+
+    #endregion
+
+    #region Enums
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum IssuedBoletoStatus
+    {
+        OPEN,
+        PAID,
+        OVERDUE,
+        CANCELLED,
+        PROTESTED
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum BoletoFineType
+    {
+        PERCENTAGE,
+        FIXED
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum BoletoInterestType
+    {
+        PERCENTAGE
+    }
+
+    #endregion
+}

--- a/Pluggy.SDK/Model/Category.cs
+++ b/Pluggy.SDK/Model/Category.cs
@@ -10,6 +10,9 @@ namespace Pluggy.SDK.Model
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        [JsonProperty("descriptionTranslated")]
+        public string DescriptionTranslated { get; set; }
+
         [JsonProperty("parentId")]
         public string ParentId { get; set; }
 

--- a/Pluggy.SDK/Model/ClientCategoryRule.cs
+++ b/Pluggy.SDK/Model/ClientCategoryRule.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Helpers;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// A client-defined transaction categorization rule.
+    /// </summary>
+    public class ClientCategoryRule
+    {
+        /// <summary>Description of the transaction rule.</summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>Identifier of the category.</summary>
+        [JsonProperty("categoryId")]
+        public string CategoryId { get; set; }
+
+        /// <summary>Description of the category.</summary>
+        [JsonProperty("category")]
+        public string Category { get; set; }
+
+        /// <summary>Identifier of the client.</summary>
+        [JsonProperty("clientId")]
+        public string ClientId { get; set; }
+
+        /// <summary>Transaction type (DEBIT/CREDIT).</summary>
+        [JsonProperty("transactionType")]
+        public string TransactionType { get; set; }
+
+        /// <summary>Account type (CHECKING_ACCOUNT/CREDIT_CARD).</summary>
+        [JsonProperty("accountType")]
+        public string AccountType { get; set; }
+    }
+
+    /// <summary>
+    /// Request to create a client category rule.
+    /// </summary>
+    public class CreateClientCategoryRule
+    {
+        /// <summary>Description of the transaction rule.</summary>
+        public string Description { get; set; }
+
+        /// <summary>Identifier of the category.</summary>
+        public string CategoryId { get; set; }
+
+        /// <summary>Transaction type (DEBIT/CREDIT) (optional).</summary>
+        public string TransactionType { get; set; }
+
+        /// <summary>Account type (CHECKING_ACCOUNT/CREDIT_CARD) (optional).</summary>
+        public string AccountType { get; set; }
+
+        /// <summary>Match type (exact/contains/startsWith/endsWith). Defaults to 'exact'.</summary>
+        public string MatchType { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "description", Description },
+                { "categoryId", CategoryId },
+                { "transactionType", TransactionType },
+                { "accountType", AccountType },
+                { "matchType", MatchType }
+            }.RemoveNulls();
+        }
+    }
+}

--- a/Pluggy.SDK/Model/Connector.cs
+++ b/Pluggy.SDK/Model/Connector.cs
@@ -33,6 +33,9 @@ namespace Pluggy.SDK.Model
         [JsonProperty("oauth")]
         public bool? Oauth { get; set; }
 
+        [JsonProperty("oauthUrl")]
+        public string OauthUrl { get; set; }
+
         [JsonProperty("resetPasswordUrl")]
         public string ResetPasswordUrl { get; set; }
 
@@ -57,7 +60,40 @@ namespace Pluggy.SDK.Model
         [JsonProperty("supportsSmartTransfers")]
         public bool SupportsSmartTransfers { get; set; }
 
+        [JsonProperty("supportsAutomaticPix")]
+        public bool SupportsAutomaticPix { get; set; }
+
+        [JsonProperty("supportsBoletoManagement")]
+        public bool SupportsBoletoManagement { get; set; }
+
+        [JsonProperty("hasMFA")]
+        public bool HasMFA { get; set; }
+
+        [JsonProperty("health")]
+        public ConnectorHealth Health { get; set; }
+
         [JsonProperty("products")]
         public IList<ProductType> Products { get; set; }
+    }
+
+    public class ConnectorHealth
+    {
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("stage")]
+        public string Stage { get; set; }
+
+        [JsonProperty("details")]
+        public ConnectorHealthDetails Details { get; set; }
+    }
+
+    public class ConnectorHealthDetails
+    {
+        [JsonProperty("connectionRateLast6Hours")]
+        public double? ConnectionRateLast6Hours { get; set; }
+
+        [JsonProperty("connectionsLast6Hours")]
+        public double? ConnectionsLast6Hours { get; set; }
     }
 }

--- a/Pluggy.SDK/Model/CurrencyCode.cs
+++ b/Pluggy.SDK/Model/CurrencyCode.cs
@@ -1,6 +1,12 @@
-﻿namespace Pluggy.SDK.Model
+﻿using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
 {
     // Based on https://en.wikipedia.org/wiki/ISO_4217
+    // Uses TolerantEnumConverter so unknown/non-ISO codes returned by the API
+    // (e.g. "GHA") fall back to BRL instead of throwing a JsonSerializationException.
+    [JsonConverter(typeof(TolerantEnumConverter), "BRL")]
     public enum CurrencyCode
     {
         AED,

--- a/Pluggy.SDK/Model/Identity.cs
+++ b/Pluggy.SDK/Model/Identity.cs
@@ -101,5 +101,19 @@ namespace Pluggy.SDK.Model
         /// <summary>CNPJs of the financial institutions responsible for the customer cadastro.</summary>
         [JsonProperty("companiesCnpj")]
         public List<string> CompaniesCnpj { get; set; }
+
+        /// <summary>
+        /// Information that allows institutions to assess and classify the client's risk profile
+        /// and economic-financial capacity (Open Finance).
+        /// </summary>
+        [JsonProperty("financialRelationships")]
+        public IdentityFinancialRelationships FinancialRelationships { get; set; }
+
+        /// <summary>
+        /// Information about since when the person has been a client of the institution and the
+        /// products/services they consume, plus income/patrimony data (Open Finance).
+        /// </summary>
+        [JsonProperty("qualifications")]
+        public IdentityQualifications Qualifications { get; set; }
     }
 }

--- a/Pluggy.SDK/Model/IdentityFinancialRelationships.cs
+++ b/Pluggy.SDK/Model/IdentityFinancialRelationships.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Financial relationship information used to assess, characterize and classify the client.
+    /// Exposed by Open Finance connectors.
+    /// </summary>
+    public class IdentityFinancialRelationships
+    {
+        /// <summary>Date when the relationship with the institution started.</summary>
+        [JsonProperty("startDate")]
+        public DateTime? StartDate { get; set; }
+
+        /// <summary>List of products and services that the client consumes.</summary>
+        [JsonProperty("productsServicesType")]
+        public List<string> ProductsServicesType { get; set; }
+
+        /// <summary>Additional info about the products and services (when productsServicesType includes 'OUTROS').</summary>
+        [JsonProperty("productsServicesTypeAdditionalInfo")]
+        public string ProductsServicesTypeAdditionalInfo { get; set; }
+
+        /// <summary>List of procurators of the client.</summary>
+        [JsonProperty("procurators")]
+        public List<IdentityProcurator> Procurators { get; set; }
+
+        /// <summary>Accounts of the client with valid consent.</summary>
+        [JsonProperty("accounts")]
+        public List<FinancialRelationshipAccount> Accounts { get; set; }
+
+        /// <summary>Salary portabilities received from the client's previous paycheck banks (PF-only).</summary>
+        [JsonProperty("portabilitiesReceived")]
+        public List<PortabilityReceived> PortabilitiesReceived { get; set; }
+
+        /// <summary>Paycheck-bank (banco-folha) links to employers, active or formerly active (PF-only).</summary>
+        [JsonProperty("paychecksBankLink")]
+        public List<PaycheckBankLink> PaychecksBankLink { get; set; }
+    }
+
+    public class IdentityProcurator
+    {
+        [JsonProperty("type")]
+        public IdentityProcuratorType? Type { get; set; }
+
+        /// <summary>CPF of the procurator (may hold a CPF or CNPJ for business links; prefer DocumentNumber + DocumentType).</summary>
+        [JsonProperty("cpfNumber")]
+        public string CpfNumber { get; set; }
+
+        /// <summary>Document number of the procurator (CPF or CNPJ). Canonical value to read.</summary>
+        [JsonProperty("documentNumber")]
+        public string DocumentNumber { get; set; }
+
+        [JsonProperty("documentType")]
+        public string DocumentType { get; set; }
+
+        [JsonProperty("civilName")]
+        public string CivilName { get; set; }
+
+        [JsonProperty("socialName")]
+        public string SocialName { get; set; }
+    }
+
+    public class FinancialRelationshipAccount
+    {
+        [JsonProperty("compeCode")]
+        public string CompeCode { get; set; }
+
+        [JsonProperty("branchCode")]
+        public string BranchCode { get; set; }
+
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        [JsonProperty("checkDigit")]
+        public string CheckDigit { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("subtype")]
+        public string Subtype { get; set; }
+    }
+
+    public class PortabilityReceived
+    {
+        [JsonProperty("employerName")]
+        public string EmployerName { get; set; }
+
+        [JsonProperty("employerDocument")]
+        public string EmployerDocument { get; set; }
+
+        [JsonProperty("paycheckBankDetainerCnpj")]
+        public string PaycheckBankDetainerCnpj { get; set; }
+
+        [JsonProperty("paycheckBankDetainerIspb")]
+        public string PaycheckBankDetainerIspb { get; set; }
+
+        [JsonProperty("portabilityApprovalDate")]
+        public DateTime? PortabilityApprovalDate { get; set; }
+    }
+
+    public class PaycheckBankLink
+    {
+        [JsonProperty("employerName")]
+        public string EmployerName { get; set; }
+
+        [JsonProperty("employerDocument")]
+        public string EmployerDocument { get; set; }
+
+        [JsonProperty("paycheckBankCnpj")]
+        public string PaycheckBankCnpj { get; set; }
+
+        [JsonProperty("paycheckBankIspb")]
+        public string PaycheckBankIspb { get; set; }
+
+        [JsonProperty("accountOpeningDate")]
+        public DateTime? AccountOpeningDate { get; set; }
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum IdentityProcuratorType
+    {
+        REPRESENTANTE_LEGAL,
+        PROCURADOR
+    }
+}

--- a/Pluggy.SDK/Model/IdentityQualifications.cs
+++ b/Pluggy.SDK/Model/IdentityQualifications.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Qualification information about the client: occupation, income, patrimony and, for businesses,
+    /// economic activities. Exposed by Open Finance connectors.
+    /// </summary>
+    public class IdentityQualifications
+    {
+        [JsonProperty("companyCnpj")]
+        public string CompanyCnpj { get; set; }
+
+        [JsonProperty("occupationCode")]
+        public IdentityOccupationCode? OccupationCode { get; set; }
+
+        /// <summary>
+        /// Free-text occupation description. Holds the standardized list code when OccupationCode is
+        /// RECEITA_FEDERAL or CBO; describes the occupation when OUTRO.
+        /// </summary>
+        [JsonProperty("occupationDescription")]
+        public string OccupationDescription { get; set; }
+
+        [JsonProperty("informedIncome")]
+        public IdentityInformedIncome InformedIncome { get; set; }
+
+        [JsonProperty("informedPatrimony")]
+        public IdentityInformedPatrimony InformedPatrimony { get; set; }
+
+        /// <summary>CNAE codes describing the economic activities of the business. Only one may be marked as main.</summary>
+        [JsonProperty("economicActivities")]
+        public List<EconomicActivity> EconomicActivities { get; set; }
+
+        [JsonProperty("informedRevenue")]
+        public InformedRevenue InformedRevenue { get; set; }
+    }
+
+    public class IdentityInformedIncome
+    {
+        [JsonProperty("frequency")]
+        public string Frequency { get; set; }
+
+        [JsonProperty("amount")]
+        public double? Amount { get; set; }
+
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+    }
+
+    public class IdentityInformedPatrimony
+    {
+        [JsonProperty("amount")]
+        public double? Amount { get; set; }
+
+        [JsonProperty("year")]
+        public double? Year { get; set; }
+
+        /// <summary>Reference date of the patrimony (returned on the business path of Open Finance).</summary>
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+    }
+
+    public class EconomicActivity
+    {
+        /// <summary>CNAE code (7 digits, including leading zeros). Follows the CNAE-Subclasse 2.3 classification.</summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>Whether this is the main economic activity (true) or a secondary one (false).</summary>
+        [JsonProperty("isMain")]
+        public bool? IsMain { get; set; }
+    }
+
+    public class InformedRevenue
+    {
+        [JsonProperty("amount")]
+        public double? Amount { get; set; }
+
+        [JsonProperty("frequency")]
+        public InformedRevenueFrequency? Frequency { get; set; }
+
+        /// <summary>Free-text complement to the frequency (when Frequency is OTHER).</summary>
+        [JsonProperty("frequencyAdditionalInfo")]
+        public string FrequencyAdditionalInfo { get; set; }
+
+        [JsonProperty("year")]
+        public double? Year { get; set; }
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum IdentityOccupationCode
+    {
+        RECEITA_FEDERAL,
+        CBO,
+        OUTRO
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum InformedRevenueFrequency
+    {
+        DAILY,
+        WEEKLY,
+        BIWEEKLY,
+        MONTHLY,
+        BIMONTHLY,
+        QUARTERLY,
+        SEMIANNUAL,
+        ANNUAL,
+        OTHER
+    }
+}

--- a/Pluggy.SDK/Model/Investment.cs
+++ b/Pluggy.SDK/Model/Investment.cs
@@ -81,6 +81,9 @@ namespace Pluggy.SDK.Model
         [JsonProperty("issueDate")]
         public DateTime? IssueDate { get; set; }
 
+        [JsonProperty("purchaseDate")]
+        public DateTime? PurchaseDate { get; set; }
+
         [JsonProperty("issuer")]
         public string Issuer { get; set; }
 

--- a/Pluggy.SDK/Model/Item.cs
+++ b/Pluggy.SDK/Model/Item.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Pluggy.SDK.Model
@@ -47,9 +48,30 @@ namespace Pluggy.SDK.Model
         [JsonProperty("nextAutoSyncAt")]
         public DateTime? NextAutoSyncAt { get; set; }
 
+        [JsonProperty("consentExpiresAt")]
+        public DateTime? ConsentExpiresAt { get; set; }
+
+        [JsonProperty("products")]
+        public IList<ProductType> Products { get; set; }
+
+        [JsonProperty("userAction")]
+        public ConnectorUserAction UserAction { get; set; }
+
         public bool HasFinished()
         {
             return Status == ItemStatus.UPDATED || Status == ItemStatus.OUTDATED || Status == ItemStatus.LOGIN_ERROR;
         }
+    }
+
+    public class ConnectorUserAction
+    {
+        [JsonProperty("instructions")]
+        public string Instructions { get; set; }
+
+        [JsonProperty("attributes")]
+        public IDictionary<string, object> Attributes { get; set; }
+
+        [JsonProperty("expiresAt")]
+        public DateTime? ExpiresAt { get; set; }
     }
 }

--- a/Pluggy.SDK/Model/Loan.cs
+++ b/Pluggy.SDK/Model/Loan.cs
@@ -49,14 +49,28 @@ namespace Pluggy.SDK.Model
         [JsonProperty("dueDate")]
         public DateTime? DueDate { get; set; }
 
-        [JsonProperty("instalmentPeriodicity")]
+        // The current API/OAS spells these with "installment" (double L). Older payloads
+        // used the British "instalment" (single L), still accepted via the *Legacy aliases below.
+        [JsonProperty("installmentPeriodicity")]
         public LoanInstalmentPeriodicity? InstalmentPeriodicity { get; set; }
 
-        [JsonProperty("instalmentPeriodicityAdditionalInfo")]
+        [JsonProperty("instalmentPeriodicity")]
+        private LoanInstalmentPeriodicity? InstalmentPeriodicityLegacy { set { InstalmentPeriodicity = value; } }
+
+        [JsonProperty("installmentPeriodicityAdditionalInfo")]
         public string InstalmentPeriodicityAdditionalInfo { get; set; }
 
-        [JsonProperty("firstInstalmentDueDate")]
+        [JsonProperty("instalmentPeriodicityAdditionalInfo")]
+        private string InstalmentPeriodicityAdditionalInfoLegacy { set { InstalmentPeriodicityAdditionalInfo = value; } }
+
+        [JsonProperty("firstInstallmentDueDate")]
         public DateTime? FirstInstalmentDueDate { get; set; }
+
+        [JsonProperty("firstInstalmentDueDate")]
+        private DateTime? FirstInstalmentDueDateLegacy { set { FirstInstalmentDueDate = value; } }
+
+        [JsonProperty("kind")]
+        public LoanKind? Kind { get; set; }
 
         [JsonProperty("CET")]
         public double? CET { get; set; }
@@ -282,6 +296,15 @@ namespace Pluggy.SDK.Model
     }
 
     #region Loan Enums
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum LoanKind
+    {
+        LOAN,
+        FINANCING,
+        INVOICE_FINANCING,
+        UNARRANGED_ACCOUNT_OVERDRAFT
+    }
 
     [JsonConverter(typeof(TolerantEnumConverter))]
     public enum LoanInstalmentPeriodicity

--- a/Pluggy.SDK/Model/Merchant.cs
+++ b/Pluggy.SDK/Model/Merchant.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Merchant (company) information, looked up by CNPJ.
+    /// </summary>
+    public class Merchant
+    {
+        /// <summary>Merchant name.</summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>Merchant legal business name.</summary>
+        [JsonProperty("businessName")]
+        public string BusinessName { get; set; }
+
+        /// <summary>Document number (CNPJ) related to the merchant.</summary>
+        [JsonProperty("cnpj")]
+        public string Cnpj { get; set; }
+
+        /// <summary>Economic activity classification (CNAE) number related to the merchant.</summary>
+        [JsonProperty("cnae")]
+        public string Cnae { get; set; }
+    }
+
+    /// <summary>
+    /// Result of a merchant lookup by CNPJ list (GET /merchants).
+    /// </summary>
+    public class GetMerchantsResponse
+    {
+        /// <summary>Merchants found for the provided CNPJs.</summary>
+        [JsonProperty("foundMerchants")]
+        public List<Merchant> FoundMerchants { get; set; }
+
+        /// <summary>Valid CNPJs that were not found in the merchant database.</summary>
+        [JsonProperty("notFoundMerchants")]
+        public List<string> NotFoundMerchants { get; set; }
+
+        /// <summary>Invalid CNPJ values provided.</summary>
+        [JsonProperty("invalidCnpjs")]
+        public List<string> InvalidCnpjs { get; set; }
+    }
+}

--- a/Pluggy.SDK/Model/SchedulePayment.cs
+++ b/Pluggy.SDK/Model/SchedulePayment.cs
@@ -1,0 +1,50 @@
+using System;
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// A scheduled payment belonging to a payment request.
+    /// </summary>
+    public class SchedulePayment
+    {
+        [JsonProperty("id")]
+        public Guid Id { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("status")]
+        public SchedulePaymentStatus Status { get; set; }
+
+        [JsonProperty("scheduledDate")]
+        public DateTime? ScheduledDate { get; set; }
+
+        [JsonProperty("endToEndId")]
+        public string EndToEndId { get; set; }
+
+        [JsonProperty("errorDetail")]
+        public SchedulePaymentErrorDetail ErrorDetail { get; set; }
+    }
+
+    public class SchedulePaymentErrorDetail
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("detail")]
+        public string Detail { get; set; }
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum SchedulePaymentStatus
+    {
+        SCHEDULED,
+        COMPLETED,
+        ERROR
+    }
+}

--- a/Pluggy.SDK/Model/SmartTransfer.cs
+++ b/Pluggy.SDK/Model/SmartTransfer.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Pluggy.SDK.Helpers;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    #region Requests
+
+    /// <summary>
+    /// Request to create a Smart Transfer payment under an existing preauthorization.
+    /// </summary>
+    public class CreateSmartTransferPayment
+    {
+        public string PreauthorizationId { get; set; }
+
+        public string RecipientId { get; set; }
+
+        public double Amount { get; set; }
+
+        public string Description { get; set; }
+
+        public string ClientPaymentId { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "preauthorizationId", PreauthorizationId },
+                { "recipientId", RecipientId },
+                { "amount", Amount },
+                { "description", Description },
+                { "clientPaymentId", ClientPaymentId }
+            }.RemoveNulls();
+        }
+    }
+
+    /// <summary>
+    /// Request to create a Smart Transfer preauthorization (recurring transfer consent).
+    /// </summary>
+    public class CreateSmartTransferPreauthorization
+    {
+        public long ConnectorId { get; set; }
+
+        /// <summary>Payer identification (CPF required, CNPJ optional).</summary>
+        public SmartTransferPreauthorizationParameter Parameters { get; set; }
+
+        public List<string> RecipientIds { get; set; }
+
+        public SmartTransferCallbackUrls CallbackUrls { get; set; }
+
+        public string ClientPreauthorizationId { get; set; }
+
+        public SmartTransferPreauthorizationConfiguration Configuration { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "connectorId", ConnectorId },
+                { "parameters", Parameters != null ? new Dictionary<string, object>
+                    {
+                        { "cpf", Parameters.Cpf },
+                        { "cnpj", Parameters.Cnpj }
+                    }.RemoveNulls() : null
+                },
+                { "recipientIds", RecipientIds != null ? RecipientIds.Cast<object>().ToList() : null },
+                { "callbackUrls", CallbackUrls != null ? new Dictionary<string, object>
+                    {
+                        { "success", CallbackUrls.Success },
+                        { "error", CallbackUrls.Error }
+                    }.RemoveNulls() : null
+                },
+                { "clientPreauthorizationId", ClientPreauthorizationId },
+                { "configuration", Configuration != null ? Configuration.ToBody() : null }
+            }.RemoveNulls();
+        }
+    }
+
+    #endregion
+
+    #region Responses
+
+    /// <summary>
+    /// A Smart Transfer payment.
+    /// </summary>
+    public class SmartTransferPayment
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("preauthorizationId")]
+        public string PreauthorizationId { get; set; }
+
+        [JsonProperty("status")]
+        public SmartTransferPaymentStatus Status { get; set; }
+
+        [JsonProperty("amount")]
+        public double Amount { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("recipient")]
+        public PaymentRecipient Recipient { get; set; }
+
+        [JsonProperty("clientPaymentId")]
+        public string ClientPaymentId { get; set; }
+
+        [JsonProperty("createdAt")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("updatedAt")]
+        public DateTime? UpdatedAt { get; set; }
+
+        [JsonProperty("errorDetail")]
+        public SmartTransferErrorDetail ErrorDetail { get; set; }
+    }
+
+    /// <summary>
+    /// A Smart Transfer preauthorization (recurring transfer consent).
+    /// </summary>
+    public class SmartTransferPreauthorization
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("status")]
+        public SmartTransferPreauthorizationStatus Status { get; set; }
+
+        [JsonProperty("consentUrl")]
+        public string ConsentUrl { get; set; }
+
+        [JsonProperty("clientPreauthorizationId")]
+        public string ClientPreauthorizationId { get; set; }
+
+        [JsonProperty("callbackUrls")]
+        public SmartTransferCallbackUrls CallbackUrls { get; set; }
+
+        [JsonProperty("recipients")]
+        public List<PaymentRecipient> Recipients { get; set; }
+
+        [JsonProperty("connector")]
+        public Connector Connector { get; set; }
+
+        [JsonProperty("createdAt")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("updatedAt")]
+        public DateTime? UpdatedAt { get; set; }
+
+        [JsonProperty("configuration")]
+        public SmartTransferPreauthorizationConfiguration Configuration { get; set; }
+
+        [JsonProperty("errorDetail")]
+        public SmartTransferErrorDetail ErrorDetail { get; set; }
+    }
+
+    public class SmartTransferErrorDetail
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("detail")]
+        public string Detail { get; set; }
+    }
+
+    #endregion
+
+    #region Shared
+
+    public class SmartTransferCallbackUrls
+    {
+        [JsonProperty("success")]
+        public string Success { get; set; }
+
+        [JsonProperty("error")]
+        public string Error { get; set; }
+    }
+
+    public class SmartTransferPreauthorizationParameter
+    {
+        [JsonProperty("cpf")]
+        public string Cpf { get; set; }
+
+        [JsonProperty("cnpj")]
+        public string Cnpj { get; set; }
+    }
+
+    public class SmartTransferPreauthorizationConfiguration
+    {
+        /// <summary>Maximum amount reachable by the sum of all transactions under this consent.</summary>
+        [JsonProperty("totalAllowedAmount")]
+        public double? TotalAllowedAmount { get; set; }
+
+        /// <summary>Maximum amount for each payment transaction.</summary>
+        [JsonProperty("transactionLimit")]
+        public double? TransactionLimit { get; set; }
+
+        [JsonProperty("periodicLimits")]
+        public SmartTransferPeriodicLimits PeriodicLimits { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "totalAllowedAmount", TotalAllowedAmount },
+                { "transactionLimit", TransactionLimit },
+                { "periodicLimits", PeriodicLimits != null ? new Dictionary<string, object>
+                    {
+                        { "day", PeriodicLimits.Day?.ToBody() },
+                        { "week", PeriodicLimits.Week?.ToBody() },
+                        { "month", PeriodicLimits.Month?.ToBody() },
+                        { "year", PeriodicLimits.Year?.ToBody() }
+                    }.RemoveNulls() : null
+                }
+            }.RemoveNulls();
+        }
+    }
+
+    public class SmartTransferPeriodicLimits
+    {
+        [JsonProperty("day")]
+        public SmartTransferPeriodicLimit Day { get; set; }
+
+        [JsonProperty("week")]
+        public SmartTransferPeriodicLimit Week { get; set; }
+
+        [JsonProperty("month")]
+        public SmartTransferPeriodicLimit Month { get; set; }
+
+        [JsonProperty("year")]
+        public SmartTransferPeriodicLimit Year { get; set; }
+    }
+
+    public class SmartTransferPeriodicLimit
+    {
+        /// <summary>Maximum number of transactions allowed in the period.</summary>
+        [JsonProperty("quantityLimit")]
+        public double? QuantityLimit { get; set; }
+
+        /// <summary>Maximum amount to be transacted in the period.</summary>
+        [JsonProperty("transactionLimit")]
+        public double? TransactionLimit { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "quantityLimit", QuantityLimit },
+                { "transactionLimit", TransactionLimit }
+            }.RemoveNulls();
+        }
+    }
+
+    #endregion
+
+    #region Enums
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum SmartTransferPaymentStatus
+    {
+        CONSENT_AUTHORIZED,
+        CONSENT_REJECTED,
+        PAYMENT_PENDING,
+        PAYMENT_PARTIALLY_ACCEPTED,
+        PAYMENT_SETTLEMENT_PROCESSING,
+        PAYMENT_SETTLEMENT_DEBTOR_ACCOUNT,
+        PAYMENT_COMPLETED,
+        PAYMENT_REJECTED,
+        ERROR
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum SmartTransferPreauthorizationStatus
+    {
+        CREATED,
+        COMPLETED,
+        REVOKED,
+        REJECTED,
+        ERROR
+    }
+
+    #endregion
+}

--- a/Pluggy.SDK/Model/Transaction.cs
+++ b/Pluggy.SDK/Model/Transaction.cs
@@ -41,6 +41,15 @@ namespace Pluggy.SDK.Model
         [JsonProperty("category")]
         public string Category { get; set; }
 
+        [JsonProperty("categoryId")]
+        public string CategoryId { get; set; }
+
+        [JsonProperty("providerId")]
+        public string ProviderId { get; set; }
+
+        [JsonProperty("order")]
+        public int? Order { get; set; }
+
         [JsonProperty("paymentData")]
         public TransactionPaymentData PaymentData { get; set; }
 
@@ -55,5 +64,11 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("operationType")]
         public string OperationType { get; set; }
+
+        [JsonProperty("createdAt")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("updatedAt")]
+        public DateTime? UpdatedAt { get; set; }
     }
 }

--- a/Pluggy.SDK/Model/UpdatePaymentRequestRequest.cs
+++ b/Pluggy.SDK/Model/UpdatePaymentRequestRequest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pluggy.SDK.Helpers;
+
+namespace Pluggy.SDK.Model
+{
+    /// <summary>
+    /// Request to update an existing payment request (PATCH /payments/requests/{id}).
+    /// All fields are optional; only provided fields are updated.
+    /// </summary>
+    public class UpdatePaymentRequestRequest
+    {
+        public double? Amount { get; set; }
+
+        public string Description { get; set; }
+
+        public PaymentCallbackUrls CallbackUrls { get; set; }
+
+        public Guid? RecipientId { get; set; }
+
+        public Guid? CustomerId { get; set; }
+
+        public string ClientPaymentId { get; set; }
+
+        public bool? IsSandbox { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "amount", Amount },
+                { "description", Description },
+                { "callbackUrls", CallbackUrls != null ? new Dictionary<string, object>
+                    {
+                        { "success", CallbackUrls.Success },
+                        { "error", CallbackUrls.Error },
+                        { "pending", CallbackUrls.Pending }
+                    }.RemoveNulls() : null
+                },
+                { "recipientId", RecipientId?.ToString() },
+                { "customerId", CustomerId?.ToString() },
+                { "clientPaymentId", ClientPaymentId },
+                { "isSandbox", IsSandbox }
+            }.RemoveNulls();
+        }
+    }
+
+    /// <summary>
+    /// Request to create a payment request from a Pix QR code (POST /payments/requests/pix-qr).
+    /// </summary>
+    public class CreatePixQrPaymentRequest
+    {
+        /// <summary>Pix QR code (copia e cola / EMV string).</summary>
+        public string PixQrCode { get; set; }
+
+        public PaymentCallbackUrls CallbackUrls { get; set; }
+
+        public Guid? CustomerId { get; set; }
+
+        public bool? IsSandbox { get; set; }
+
+        public Dictionary<string, object> ToBody()
+        {
+            return new Dictionary<string, object>
+            {
+                { "pixQrCode", PixQrCode },
+                { "callbackUrls", CallbackUrls != null ? new Dictionary<string, object>
+                    {
+                        { "success", CallbackUrls.Success },
+                        { "error", CallbackUrls.Error },
+                        { "pending", CallbackUrls.Pending }
+                    }.RemoveNulls() : null
+                },
+                { "customerId", CustomerId?.ToString() },
+                { "isSandbox", IsSandbox }
+            }.RemoveNulls();
+        }
+    }
+}

--- a/Pluggy.SDK/PluggyAPI.cs
+++ b/Pluggy.SDK/PluggyAPI.cs
@@ -29,9 +29,17 @@ namespace Pluggy.SDK
         protected static readonly string URL_CONSENTS = "/consents";
         protected static readonly string URL_LOANS = "/loans";
         protected static readonly string URL_PAYMENT_RECIPIENTS = "/payments/recipients";
+        protected static readonly string URL_PAYMENT_RECIPIENT_INSTITUTIONS = "/payments/recipients/institutions";
         protected static readonly string URL_PAYMENT_REQUESTS = "/payments/requests";
         protected static readonly string URL_PAYMENT_INTENTS = "/payments/intents";
         protected static readonly string URL_PAYMENT_CUSTOMERS = "/payments/customers";
+        protected static readonly string URL_CATEGORY_RULES = "/categories/rules";
+        protected static readonly string URL_BILLS = "/bills";
+        protected static readonly string URL_MERCHANTS = "/merchants";
+        protected static readonly string URL_SMART_TRANSFER_PAYMENTS = "/smart-transfers/payments";
+        protected static readonly string URL_SMART_TRANSFER_PREAUTHORIZATIONS = "/smart-transfers/preauthorizations";
+        protected static readonly string URL_BOLETOS = "/boletos";
+        protected static readonly string URL_BOLETO_CONNECTIONS = "/boleto-connections";
 
         public static readonly int STATUS_POLL_INTERVAL = 3000;
 
@@ -188,6 +196,16 @@ namespace Pluggy.SDK
         public async Task<Account> FetchAccount(Guid id)
         {
             return await httpService.GetAsync<Account>(URL_ACCOUNTS + "/{id}", HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Fetch the point-in-time balance of an account
+        /// </summary>
+        /// <param name="id">Account Id</param>
+        /// <returns>Account balance</returns>
+        public async Task<AccountBalance> FetchAccountBalance(Guid id)
+        {
+            return await httpService.GetAsync<AccountBalance>(URL_ACCOUNTS + "/{id}/balance", HTTP.Utils.GetSegment(id.ToString()));
         }
 
         /// <summary>
@@ -594,6 +612,136 @@ namespace Pluggy.SDK
             await httpService.DeleteAsync<dynamic>(URL_PAYMENT_REQUESTS + "/{id}", HTTP.Utils.GetSegment(id.ToString()), null);
         }
 
+        /// <summary>
+        /// Update a payment request
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <param name="request">Fields to update</param>
+        /// <returns>Updated payment request</returns>
+        public async Task<PaymentRequest> UpdatePaymentRequest(Guid id, UpdatePaymentRequestRequest request)
+        {
+            return await httpService.PatchAsync<PaymentRequest>(URL_PAYMENT_REQUESTS + "/{id}", request.ToBody(), null, HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Create a payment request from a Pix QR code
+        /// </summary>
+        /// <param name="request">Pix QR payment request</param>
+        /// <returns>Created payment request</returns>
+        public async Task<PaymentRequest> CreatePixQrPaymentRequest(CreatePixQrPaymentRequest request)
+        {
+            return await httpService.PostAsync<PaymentRequest>(URL_PAYMENT_REQUESTS + "/pix-qr", request.ToBody());
+        }
+
+        /// <summary>
+        /// Fetch the scheduled payments of a payment request
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <returns>Scheduled payments list</returns>
+        public async Task<PageResults<SchedulePayment>> FetchPaymentRequestSchedules(Guid id)
+        {
+            return await httpService.GetAsync<PageResults<SchedulePayment>>(URL_PAYMENT_REQUESTS + "/{id}/schedules", HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Cancel all scheduled payments of a payment request
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        public async Task CancelPaymentRequestSchedules(Guid id)
+        {
+            await httpService.PostAsync<dynamic>(URL_PAYMENT_REQUESTS + "/{id}/schedules/cancel", null, null, HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Cancel a specific scheduled payment of a payment request
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <param name="scheduleId">Scheduled payment ID</param>
+        public async Task CancelPaymentRequestSchedule(Guid id, Guid scheduleId)
+        {
+            await httpService.PostAsync<dynamic>(URL_PAYMENT_REQUESTS + "/{id}/schedules/{scheduleId}/cancel", null, null,
+                new Dictionary<string, string> { { "id", id.ToString() }, { "scheduleId", scheduleId.ToString() } });
+        }
+
+        #endregion
+
+        #region Automatic Pix
+
+        /// <summary>
+        /// Create an Automatic Pix payment request (recurring Pix consent)
+        /// </summary>
+        /// <param name="request">Automatic Pix creation request</param>
+        /// <returns>Created payment request with paymentUrl</returns>
+        public async Task<PaymentRequest> CreateAutomaticPixPaymentRequest(CreateAutomaticPixPaymentRequest request)
+        {
+            return await httpService.PostAsync<PaymentRequest>(URL_PAYMENT_REQUESTS + "/automatic-pix", request.ToBody());
+        }
+
+        /// <summary>
+        /// Cancel an Automatic Pix consent
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        public async Task CancelAutomaticPixConsent(Guid id)
+        {
+            await httpService.PostAsync<dynamic>(URL_PAYMENT_REQUESTS + "/{id}/automatic-pix/cancel", null, null, HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Schedule an Automatic Pix payment under an existing consent
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <param name="request">Schedule request</param>
+        /// <returns>Scheduled Automatic Pix payment</returns>
+        public async Task<AutomaticPixPayment> ScheduleAutomaticPixPayment(Guid id, ScheduleAutomaticPixPaymentRequest request)
+        {
+            return await httpService.PostAsync<AutomaticPixPayment>(URL_PAYMENT_REQUESTS + "/{id}/automatic-pix/schedule", request.ToBody(), null, HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Fetch the Automatic Pix scheduled payments of a payment request
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <returns>Automatic Pix payments list</returns>
+        public async Task<PageResults<AutomaticPixPayment>> FetchAutomaticPixSchedules(Guid id)
+        {
+            return await httpService.GetAsync<PageResults<AutomaticPixPayment>>(URL_PAYMENT_REQUESTS + "/{id}/automatic-pix/schedules", HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        /// <summary>
+        /// Fetch a single Automatic Pix scheduled payment
+        /// </summary>
+        /// <param name="requestId">Payment request ID</param>
+        /// <param name="paymentId">Automatic Pix payment ID</param>
+        /// <returns>Automatic Pix payment detail</returns>
+        public async Task<AutomaticPixPayment> FetchAutomaticPixSchedule(Guid requestId, string paymentId)
+        {
+            return await httpService.GetAsync<AutomaticPixPayment>(URL_PAYMENT_REQUESTS + "/{requestId}/automatic-pix/schedules/{paymentId}",
+                new Dictionary<string, string> { { "requestId", requestId.ToString() }, { "paymentId", paymentId } });
+        }
+
+        /// <summary>
+        /// Cancel an Automatic Pix scheduled payment
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <param name="scheduleId">Automatic Pix payment ID</param>
+        public async Task CancelAutomaticPixSchedule(Guid id, string scheduleId)
+        {
+            await httpService.PostAsync<dynamic>(URL_PAYMENT_REQUESTS + "/{id}/automatic-pix/schedules/{scheduleId}/cancel", null, null,
+                new Dictionary<string, string> { { "id", id.ToString() }, { "scheduleId", scheduleId } });
+        }
+
+        /// <summary>
+        /// Retry an Automatic Pix scheduled payment
+        /// </summary>
+        /// <param name="id">Payment request ID</param>
+        /// <param name="scheduleId">Automatic Pix payment ID</param>
+        /// <param name="request">Retry request (target date)</param>
+        public async Task RetryAutomaticPixSchedule(Guid id, string scheduleId, RetryAutomaticPixPaymentRequest request)
+        {
+            await httpService.PostAsync<dynamic>(URL_PAYMENT_REQUESTS + "/{id}/automatic-pix/schedules/{scheduleId}/retry", request.ToBody(), null,
+                new Dictionary<string, string> { { "id", id.ToString() }, { "scheduleId", scheduleId } });
+        }
+
         #endregion
 
         #region Payment Intents
@@ -682,7 +830,210 @@ namespace Pluggy.SDK
 
         #endregion
 
-        
+        #region Payment Recipient Institutions
+
+        /// <summary>
+        /// Fetch the list of payment recipient institutions
+        /// </summary>
+        /// <returns>Payment institutions list</returns>
+        public async Task<PageResults<PaymentInstitution>> FetchPaymentRecipientInstitutions()
+        {
+            return await httpService.GetAsync<PageResults<PaymentInstitution>>(URL_PAYMENT_RECIPIENT_INSTITUTIONS);
+        }
+
+        /// <summary>
+        /// Fetch a payment recipient institution by ID
+        /// </summary>
+        /// <param name="id">Institution ID</param>
+        /// <returns>Payment institution details</returns>
+        public async Task<PaymentInstitution> FetchPaymentRecipientInstitution(Guid id)
+        {
+            return await httpService.GetAsync<PaymentInstitution>(URL_PAYMENT_RECIPIENT_INSTITUTIONS + "/{id}", HTTP.Utils.GetSegment(id.ToString()));
+        }
+
+        #endregion
+
+        #region Smart Transfers
+
+        /// <summary>
+        /// Create a Smart Transfer payment under an existing preauthorization
+        /// </summary>
+        /// <param name="request">Smart Transfer payment request</param>
+        /// <returns>Created Smart Transfer payment</returns>
+        public async Task<SmartTransferPayment> CreateSmartTransferPayment(CreateSmartTransferPayment request)
+        {
+            return await httpService.PostAsync<SmartTransferPayment>(URL_SMART_TRANSFER_PAYMENTS, request.ToBody());
+        }
+
+        /// <summary>
+        /// Fetch a Smart Transfer payment by ID
+        /// </summary>
+        /// <param name="id">Smart Transfer payment ID</param>
+        /// <returns>Smart Transfer payment details</returns>
+        public async Task<SmartTransferPayment> FetchSmartTransferPayment(string id)
+        {
+            return await httpService.GetAsync<SmartTransferPayment>(URL_SMART_TRANSFER_PAYMENTS + "/{id}", HTTP.Utils.GetSegment(id));
+        }
+
+        /// <summary>
+        /// Create a Smart Transfer preauthorization (recurring transfer consent)
+        /// </summary>
+        /// <param name="request">Preauthorization request</param>
+        /// <returns>Created Smart Transfer preauthorization with consentUrl</returns>
+        public async Task<SmartTransferPreauthorization> CreateSmartTransferPreauthorization(CreateSmartTransferPreauthorization request)
+        {
+            return await httpService.PostAsync<SmartTransferPreauthorization>(URL_SMART_TRANSFER_PREAUTHORIZATIONS, request.ToBody());
+        }
+
+        /// <summary>
+        /// Fetch all Smart Transfer preauthorizations
+        /// </summary>
+        /// <returns>Preauthorizations list</returns>
+        public async Task<PageResults<SmartTransferPreauthorization>> FetchSmartTransferPreauthorizations()
+        {
+            return await httpService.GetAsync<PageResults<SmartTransferPreauthorization>>(URL_SMART_TRANSFER_PREAUTHORIZATIONS);
+        }
+
+        /// <summary>
+        /// Fetch a Smart Transfer preauthorization by ID
+        /// </summary>
+        /// <param name="id">Preauthorization ID</param>
+        /// <returns>Preauthorization details</returns>
+        public async Task<SmartTransferPreauthorization> FetchSmartTransferPreauthorization(string id)
+        {
+            return await httpService.GetAsync<SmartTransferPreauthorization>(URL_SMART_TRANSFER_PREAUTHORIZATIONS + "/{id}", HTTP.Utils.GetSegment(id));
+        }
+
+        /// <summary>
+        /// Fetch the payments of a Smart Transfer preauthorization
+        /// </summary>
+        /// <param name="id">Preauthorization ID</param>
+        /// <returns>Smart Transfer payments list</returns>
+        public async Task<PageResults<SmartTransferPayment>> FetchSmartTransferPreauthorizationPayments(string id)
+        {
+            return await httpService.GetAsync<PageResults<SmartTransferPayment>>(URL_SMART_TRANSFER_PREAUTHORIZATIONS + "/{id}/payments", HTTP.Utils.GetSegment(id));
+        }
+
+        #endregion
+
+        #region Category Rules
+
+        /// <summary>
+        /// Fetch the list of client category rules
+        /// </summary>
+        /// <returns>Category rules paged results list</returns>
+        public async Task<PageResults<ClientCategoryRule>> FetchCategoryRules()
+        {
+            return await httpService.GetAsync<PageResults<ClientCategoryRule>>(URL_CATEGORY_RULES);
+        }
+
+        /// <summary>
+        /// Create a client category rule
+        /// </summary>
+        /// <param name="request">Category rule creation request</param>
+        /// <returns>Created category rule</returns>
+        public async Task<ClientCategoryRule> CreateCategoryRule(CreateClientCategoryRule request)
+        {
+            return await httpService.PostAsync<ClientCategoryRule>(URL_CATEGORY_RULES, request.ToBody());
+        }
+
+        #endregion
+
+        #region Bills
+
+        /// <summary>
+        /// Fetch the list of credit card bills for an account
+        /// </summary>
+        /// <param name="accountId">Account ID</param>
+        /// <returns>Bills paged results list</returns>
+        public async Task<PageResults<Bill>> FetchBills(Guid accountId)
+        {
+            var queryStrings = new Dictionary<string, string> { { "accountId", accountId.ToString() } };
+            return await httpService.GetAsync<PageResults<Bill>>(URL_BILLS, null, queryStrings);
+        }
+
+        /// <summary>
+        /// Fetch a bill by ID
+        /// </summary>
+        /// <param name="id">Bill ID</param>
+        /// <returns>Bill details</returns>
+        public async Task<Bill> FetchBill(string id)
+        {
+            return await httpService.GetAsync<Bill>(URL_BILLS + "/{id}", HTTP.Utils.GetSegment(id));
+        }
+
+        #endregion
+
+        #region Merchants
+
+        /// <summary>
+        /// Look up merchants by CNPJ list
+        /// </summary>
+        /// <param name="cnpjs">List of CNPJs to look up</param>
+        /// <returns>Found merchants, plus valid-but-not-found and invalid CNPJs</returns>
+        public async Task<GetMerchantsResponse> FetchMerchants(IEnumerable<string> cnpjs)
+        {
+            var queryStrings = new Dictionary<string, string> { { "cnpjs", string.Join(",", cnpjs) } };
+            return await httpService.GetAsync<GetMerchantsResponse>(URL_MERCHANTS, null, queryStrings);
+        }
+
+        #endregion
+
+        #region Boleto Management (Beta)
+
+        /// <summary>
+        /// BETA. Create a boleto connection from credentials.
+        /// </summary>
+        /// <param name="request">Boleto connection request</param>
+        /// <returns>Created boleto connection</returns>
+        public async Task<BoletoConnection> CreateBoletoConnection(CreateBoletoConnection request)
+        {
+            return await httpService.PostAsync<BoletoConnection>(URL_BOLETO_CONNECTIONS, request.ToBody());
+        }
+
+        /// <summary>
+        /// BETA. Create a boleto connection from an existing item.
+        /// </summary>
+        /// <param name="request">Boleto connection from item request</param>
+        /// <returns>Created boleto connection</returns>
+        public async Task<BoletoConnection> CreateBoletoConnectionFromItem(CreateBoletoConnectionFromItem request)
+        {
+            return await httpService.PostAsync<BoletoConnection>(URL_BOLETO_CONNECTIONS + "/from-item", request.ToBody());
+        }
+
+        /// <summary>
+        /// BETA. Issue a boleto.
+        /// </summary>
+        /// <param name="request">Boleto creation request</param>
+        /// <returns>Issued boleto</returns>
+        public async Task<IssuedBoleto> CreateBoleto(CreateBoleto request)
+        {
+            return await httpService.PostAsync<IssuedBoleto>(URL_BOLETOS, request.ToBody());
+        }
+
+        /// <summary>
+        /// BETA. Fetch a boleto by ID.
+        /// </summary>
+        /// <param name="id">Boleto ID</param>
+        /// <returns>Issued boleto</returns>
+        public async Task<IssuedBoleto> FetchBoleto(string id)
+        {
+            return await httpService.GetAsync<IssuedBoleto>(URL_BOLETOS + "/{id}", HTTP.Utils.GetSegment(id));
+        }
+
+        /// <summary>
+        /// BETA. Cancel a boleto.
+        /// </summary>
+        /// <param name="id">Boleto ID</param>
+        /// <returns>Issued boleto with updated status</returns>
+        public async Task<IssuedBoleto> CancelBoleto(string id)
+        {
+            return await httpService.PostAsync<IssuedBoleto>(URL_BOLETOS + "/{id}/cancel", null, null, HTTP.Utils.GetSegment(id));
+        }
+
+        #endregion
+
+
         /*
          * Execution Helpers
          */

--- a/Pluggy.Tests/Helpers/TolerantEnumConverterTest.cs
+++ b/Pluggy.Tests/Helpers/TolerantEnumConverterTest.cs
@@ -58,5 +58,50 @@ namespace Pluggy.Tests
             Assert.AreEqual(result.NullableTypeWithValidStringValue, InvestmentType.SECURITY);
 
         }
+
+        [Test]
+        public void CurrencyCode_ShouldFallBackToBRL_ForUnknownCode()
+        {
+            // "GHA" is not a valid ISO 4217 code (Ghana's currency is GHS) and is not
+            // present in the CurrencyCode enum. It must not throw; it falls back to BRL.
+            var account = JsonConvert.DeserializeObject<Account>(@"{ ""currencyCode"": ""GHA"" }");
+            Assert.AreEqual(CurrencyCode.BRL, account.CurrencyCode);
+        }
+
+        [Test]
+        public void CurrencyCode_ShouldParseKnownCode()
+        {
+            var account = JsonConvert.DeserializeObject<Account>(@"{ ""currencyCode"": ""USD"" }");
+            Assert.AreEqual(CurrencyCode.USD, account.CurrencyCode);
+        }
+
+        [Test]
+        public void Loan_ShouldParseInstallmentFields_OasSpelling()
+        {
+            var loan = JsonConvert.DeserializeObject<Loan>(@"
+            {
+                ""installmentPeriodicity"": ""MONTHLY"",
+                ""installmentPeriodicityAdditionalInfo"": ""info"",
+                ""firstInstallmentDueDate"": ""2024-01-15T00:00:00.000Z""
+            }");
+            Assert.AreEqual(LoanInstalmentPeriodicity.MONTHLY, loan.InstalmentPeriodicity);
+            Assert.AreEqual("info", loan.InstalmentPeriodicityAdditionalInfo);
+            Assert.IsNotNull(loan.FirstInstalmentDueDate);
+        }
+
+        [Test]
+        public void Loan_ShouldParseInstallmentFields_LegacySpelling()
+        {
+            // Older payloads used the British "instalment" (single L). Must still bind.
+            var loan = JsonConvert.DeserializeObject<Loan>(@"
+            {
+                ""instalmentPeriodicity"": ""MONTHLY"",
+                ""instalmentPeriodicityAdditionalInfo"": ""info"",
+                ""firstInstalmentDueDate"": ""2024-01-15T00:00:00.000Z""
+            }");
+            Assert.AreEqual(LoanInstalmentPeriodicity.MONTHLY, loan.InstalmentPeriodicity);
+            Assert.AreEqual("info", loan.InstalmentPeriodicityAdditionalInfo);
+            Assert.IsNotNull(loan.FirstInstalmentDueDate);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Started as two fixes and grew into a **full sync of the SDK with OAS v1.0.0**.

### 1. Currency codes no longer break deserialization
`CurrencyCode` is a hand-curated ISO 4217 enum, but the API returns `currencyCode` as a free-form string. Unlisted/non-ISO codes like `"GHA"` (not valid ISO — Ghana is `GHS`) threw `JsonSerializationException`. `TolerantEnumConverter` now takes a configurable fallback and `CurrencyCode` uses `[JsonConverter(typeof(TolerantEnumConverter), "BRL")]` → unknown codes resolve to BRL instead of throwing. Property stays non-nullable (no breaking change).

### 2. Model field sync + Loan bug fix
New fields on Account, Transaction, Investment, Connector, Item, Category, Loan, Identity (+ ConnectorHealth, ConnectorUserAction, LoanKind, IdentityFinancialRelationships, IdentityQualifications and nested Open Finance PF/PJ types). **Loan fix:** installment JSON keys were spelled `instalment` (single L) and no longer bound to the OAS (`installment`, double L); realigned + kept legacy spelling via private aliases.

### 3. Endpoint sync
- **Automatic Pix** — create consent, schedule/cancel/retry, list/get schedules
- **Smart Transfers** — payments + preauthorizations (create/list/get/payments)
- **Bills** — `GET /bills`, `GET /bills/{id}`
- **Merchants** — `GET /merchants` (CNPJ batch lookup)
- **Category Rules** — `GET`/`POST /categories/rules`
- **Payment Recipient Institutions** — list + get
- **Account balance** — `GET /accounts/{id}/balance`
- **Payment schedules** — list + cancel-all + cancel-one
- **UpdatePaymentRequest** (PATCH) and **Pix QR** (POST)
- **Boleto Management (beta)** — connections, issue, get, cancel — marked `BETA` in code

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 14/14 pass (currency GHA→BRL, USD→USD, Loan installment OAS + legacy spelling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)