### PR TITLE
feat: add operationTypeAdditionalInfo to Transaction

### DIFF
--- a/Pluggy.SDK/Model/Transaction.cs
+++ b/Pluggy.SDK/Model/Transaction.cs
@@ -55,5 +55,8 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("operationType")]
         public string OperationType { get; set; }
+
+        [JsonProperty("operationTypeAdditionalInfo")]
+        public string OperationTypeAdditionalInfo { get; set; }
     }
 }


### PR DESCRIPTION
Adds the `operationTypeAdditionalInfo` field to the Transaction model — a free-form complement to `operationType`, returned by the API for Open Finance connectors. It varies by institution (a sub-type code or a description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
