### PR TITLE
feat: add new Open Finance credit card fields

### DIFF
--- a/Pluggy.SDK/Model/Account.cs
+++ b/Pluggy.SDK/Model/Account.cs
@@ -83,6 +83,10 @@ namespace Pluggy.SDK.Model
         [JsonProperty("brand")]
         public string Brand { get; set; }
 
+        // Free text to specify the brand category when brand is marked as "OTHER".
+        [JsonProperty("brandAdditionalInfo")]
+        public string BrandAdditionalInfo { get; set; }
+
         [JsonProperty("balanceCloseDate")]
         public DateTime? BalanceCloseDate { get; set; }
 
@@ -110,6 +114,60 @@ namespace Pluggy.SDK.Model
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        [JsonProperty("disaggregatedCreditLimits")]
+        public ICollection<DisaggregatedCreditLimit> DisaggregatedCreditLimits { get; set; }
+
+    }
+
+    public class DisaggregatedCreditLimit
+    {
+        [JsonProperty("creditLineLimitType")]
+        public string CreditLineLimitType { get; set; }
+
+        [JsonProperty("consolidationType")]
+        public string ConsolidationType { get; set; }
+
+        [JsonProperty("identificationNumber")]
+        public string IdentificationNumber { get; set; }
+
+        [JsonProperty("isLimitFlexible")]
+        public bool? IsLimitFlexible { get; set; }
+
+        [JsonProperty("lineName")]
+        public CreditCardLimitLineName LineName { get; set; }
+
+        [JsonProperty("lineNameAdditionalInfo")]
+        public string LineNameAdditionalInfo { get; set; }
+
+        [JsonProperty("limitAmount")]
+        public double? LimitAmount { get; set; }
+
+        [JsonProperty("limitAmountCurrencyCode")]
+        public CurrencyCode? LimitAmountCurrencyCode { get; set; }
+
+        // Reason why the reported total limit amount is equal to zero.
+        [JsonProperty("limitAmountReason")]
+        public string LimitAmountReason { get; set; }
+
+        [JsonProperty("usedAmount")]
+        public double? UsedAmount { get; set; }
+
+        [JsonProperty("usedAmountCurrencyCode")]
+        public CurrencyCode? UsedAmountCurrencyCode { get; set; }
+
+        [JsonProperty("availableAmount")]
+        public double? AvailableAmount { get; set; }
+
+        [JsonProperty("availableAmountCurrencyCode")]
+        public CurrencyCode? AvailableAmountCurrencyCode { get; set; }
+
+        // Total limit amount customized by the customer through the institution's electronic channels.
+        [JsonProperty("customizedLimitAmount")]
+        public double? CustomizedLimitAmount { get; set; }
+
+        // Currency of the reported customized limit amount.
+        [JsonProperty("customizedLimitAmountCurrencyCode")]
+        public CurrencyCode? CustomizedLimitAmountCurrencyCode { get; set; }
     }
 }
 

--- a/Pluggy.SDK/Model/CreditCardAccountFeeType.cs
+++ b/Pluggy.SDK/Model/CreditCardAccountFeeType.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum CreditCardAccountFeeType
+    {
+        ANNUAL_FEE,
+        ATM_WITHDRAWAL_DOMESTIC,
+        ATM_WITHDRAWAL_INTERNATIONAL,
+        EMERGENCY_CREDIT_EVALUATION,
+        CARD_REISSUE,
+        BILL_PAYMENT_FEE,
+        SMS,
+        OTHER,
+    }
+}

--- a/Pluggy.SDK/Model/CreditCardAccountOtherCreditType.cs
+++ b/Pluggy.SDK/Model/CreditCardAccountOtherCreditType.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum CreditCardAccountOtherCreditType
+    {
+        REVOLVING_CREDIT,
+        BILL_INSTALLMENT,
+        LOAN,
+        OTHER,
+    }
+}

--- a/Pluggy.SDK/Model/CreditCardLimitLineName.cs
+++ b/Pluggy.SDK/Model/CreditCardLimitLineName.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+using Pluggy.SDK.Utils;
+
+namespace Pluggy.SDK.Model
+{
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum CreditCardLimitLineName
+    {
+        CREDITO_A_VISTA,
+        CREDITO_PARCELADO,
+        SAQUE_CREDITO_BRASIL,
+        SAQUE_CREDITO_EXTERIOR,
+        EMPRESTIMO_CARTAO_CONSIGNADO,
+        OUTROS,
+    }
+}

--- a/Pluggy.SDK/Model/TransactionCreditCardMetadata.cs
+++ b/Pluggy.SDK/Model/TransactionCreditCardMetadata.cs
@@ -25,6 +25,22 @@ namespace Pluggy.SDK.Model
 
         [JsonProperty("cardNumber")]
         public string CardNumber { get; set; }
+
+        // Type of fee charged. Present when the operation is a fee (TARIFA).
+        [JsonProperty("feeType")]
+        public CreditCardAccountFeeType? FeeType { get; set; }
+
+        // Free text describing the fee type when feeType is "OTHER".
+        [JsonProperty("feeTypeAdditionalInfo")]
+        public string FeeTypeAdditionalInfo { get; set; }
+
+        // Other type of credit contracted on the card. Present when the operation is a contracted credit operation.
+        [JsonProperty("otherCreditsType")]
+        public CreditCardAccountOtherCreditType? OtherCreditsType { get; set; }
+
+        // Free text describing the other credit type when otherCreditsType is "OTHER".
+        [JsonProperty("otherCreditsAdditionalInfo")]
+        public string OtherCreditsAdditionalInfo { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary

The Pluggy API now returns additional Open Finance credit-card fields. This PR models them in the SDK so consumers can read them.

**`CreditAccount` (`creditData`):**
- `BrandAdditionalInfo` (string) — free text describing the brand category when `brand` is `OTHER`.
- `DisaggregatedCreditLimits` — collection of the new `DisaggregatedCreditLimit` type.

**`DisaggregatedCreditLimit` (new type):**
- `LineName` (new `CreditCardLimitLineName` enum)
- `LimitAmountReason` (string) — reason why the reported total limit amount is zero.
- `CustomizedLimitAmount` (double?) — total limit amount customized by the customer through the institution's electronic channels.
- `CustomizedLimitAmountCurrencyCode` (`CurrencyCode?`) — currency of the customized limit amount.
- plus the standard OF limit fields (`creditLineLimitType`, `consolidationType`, `identificationNumber`, `isLimitFlexible`, `lineNameAdditionalInfo`, `limitAmount` / `usedAmount` / `availableAmount` and their currency codes).

**`TransactionCreditCardMetadata` (`creditCardMetadata`):**
- `FeeType` (new `CreditCardAccountFeeType` enum)
- `FeeTypeAdditionalInfo` (string)
- `OtherCreditsType` (new `CreditCardAccountOtherCreditType` enum)
- `OtherCreditsAdditionalInfo` (string)

**New enums** (using `TolerantEnumConverter`, matching the existing credit-card enum style):
- `CreditCardLimitLineName`
- `CreditCardAccountFeeType`
- `CreditCardAccountOtherCreditType`

## Test plan

- `dotnet build` (verified locally via the netstandard2.0 toolchain: SDK compiles cleanly, 0 errors).
- The net8.0 test project (`Pluggy.Tests`) could not be exercised in this environment (no .NET 8 SDK), but these are additive, model-only changes with no behavior changes; new enums use the existing `TolerantEnumConverter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)